### PR TITLE
Add macOS Build Script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -21,7 +21,3 @@ assignees: lassandroan
 ## Steps to Reproduce the Problem
 
   1.
-
-## Other
-
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,3 @@
 ## Changes
 
 
-  
-## Other

--- a/Scripts/macOS/Compile.sh
+++ b/Scripts/macOS/Compile.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 # Copyright (C) 2021 Antonio Lassandro
 
 # This program is free software: you can redistribute it and/or modify it
@@ -14,5 +16,107 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -e
+
+NAME="Fang"
+VERSION="0.0.0"
+
+RUN=0
+DEBUG=0
+RELEASE=0
+
+COMPILE_FLAGS=" "
+
+while [ "$1" != "" ]; do
+    case $1 in
+        "ubsan" )
+            echo "Compiling with undefined behavior sanitizer..."
+            COMPILE_FLAGS+="-fsanitize=undefined "
+            ;;
+
+        "asan" )
+            echo "Compiling with address sanitizer..."
+            COMPILE_FLAGS+="-fsanitize=address "
+            ;;
+
+        "release" )
+            RELEASE=1
+            ;;
+
+        "debug" )
+            DEBUG=1
+            ;;
+
+        "run" )
+            RUN=1
+            ;;
+
+        * )
+            echo "Unrecognized flag '$1'"
+            echo "\$./Scripts/macOS/Compile.sh [debug|release] [asan|ubsan] [run]"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+COMPILE_FLAGS+="-std=c11 "
+COMPILE_FLAGS+="-pedantic "
+COMPILE_FLAGS+="-Wall "
+COMPILE_FLAGS+="-Wextra "
+COMPILE_FLAGS+="-Wconversion "
+COMPILE_FLAGS+="-Werror "
+COMPILE_FLAGS+="-mmacosx-version-min=10.9 "
+COMPILE_FLAGS+="-F/Library/Frameworks/ "
+COMPILE_FLAGS+="-DFANG_TITLE=\"$NAME\" "
+COMPILE_FLAGS+="-DFANG_VERSION=\"$VERSION\" "
+
+DIR_BUILD="Build"
+
+if test $RELEASE -eq 1; then
+    COMPILE_FLAGS+="-O3 "
+    DIR_BUILD+="/Release"
+else
+    COMPILE_FLAGS+="-g "
+    DIR_BUILD+="/Debug"
+fi
+
+DIR_APP="$DIR_BUILD/$NAME.app"
+DIR_CONTENTS="$DIR_APP/Contents"
+DIR_MACOS="$DIR_CONTENTS/MacOS"
+DIR_RESOURCES="$DIR_CONTENTS/Resources"
+DIR_FRAMEWORKS="$DIR_CONTENTS/Frameworks"
+
+BINARY="$DIR_MACOS/$NAME"
+PLIST="$DIR_CONTENTS/Info.plist"
+
+rm -rf "$DIR_BUILD"
+mkdir -p "$DIR_MACOS"
+mkdir -p "$DIR_RESOURCES"
+mkdir -p "$DIR_FRAMEWORKS"
+
+cp "Scripts/macOS/Info.plist" "$PLIST"
+plutil -insert "CFBundleName" -string "$NAME" -s "$PLIST"
+plutil -insert "CFBundleDisplayName" -string "$NAME" -s "$PLIST"
+plutil -insert "CFBundleIdentifier" -string "com.lassandroan.$NAME" -s "$PLIST"
+plutil -insert "CFBundleExecutable" -string "$NAME" -s "$PLIST"
+plutil -insert "CFBundleVersion" -string "$VERISON" -s "$PLIST"
+plutil -insert "CFBundleShortVersionString" -string "$VERISON" -s "$PLIST"
+plutil -lint -s "$PLIST"
+
+cp -r "Resources/" "$DIR_RESOURCES"
+
+cc \
+    $COMPILE_FLAGS \
+    $(sdl2-config --cflags --libs) \
+    -o "$BINARY" \
+    "Source/Main.c"
+
+if test $DEBUG -eq 1; then
+    echo "Launching debugger..."
+    lldb -o run "./$BINARY"
+elif test $RUN -eq 1; then
+    echo "Launching game..."
+    "./$BINARY"
+fi
 
 echo "Done"

--- a/Scripts/macOS/Info.plist
+++ b/Scripts/macOS/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>English</string>
+        <key>CFBundleIconFile</key>
+        <string>AppIcon</string>
+        <key>CFBundleIconName</key>
+        <string>AppIcon</string>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>NSHumanReadableCopyright</key>
+        <string>Copyright Antonio Lassandro</string>
+        <key>LSArchitecturePriority</key>
+        <array>
+            <string>x86_64</string>
+        </array>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>English</string>
+        <key>LSApplicationCategoryType</key>
+        <string>public.app-category.games</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>10.9.0</string>
+        <key>NSHighResolutionCapable</key>
+        <true/>
+        <key>NSQuitAlwaysKeepsWindows</key>
+        <false/>
+    </dict>
+</plist>

--- a/Source/Main.c
+++ b/Source/Main.c
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+// License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
Resolves #1 

## Description

Sets up the project to build on macOS

```bash
$ ./Scripts/macOS/Compile.sh [debug|release] [asan|ubsan] [run]
```

## Changes

- Adds `Scripts/macOS/Compile.sh`, `Scripts/macOS/Info.plist`
- Adds `Source/Main.c` main compilation target
