### PR TITLE
Add SDL Initialization

### DIFF
--- a/Fang.sublime-project
+++ b/Fang.sublime-project
@@ -35,31 +35,62 @@
             "file_regex": "^(..[^:\n]*):([0-9]+):?([0-9]+)?:? (.*)$",
             "syntax": "Packages/Makefile/Make Output.sublime-syntax",
             "osx": {
-                "cmd": ["sh", "Scripts/macOS/Compile.sh", "run"],
+                "cmd": [
+                    "sh",
+                    "Scripts/macOS/Compile.sh",
+                    "run",
+                    "-DFANG_UNBUFFERED_STDOUT",
+                ],
             },
             "variants": [
                 {
                     "name": "Debug",
                     "osx": {
-                        "cmd": ["sh", "Scripts/macOS/Compile.sh", "run", "debug"]
+                        "cmd": [
+                            "sh",
+                            "Scripts/macOS/Compile.sh",
+                            "run",
+                            "debug",
+                            "-DFANG_UNBUFFERED_STDOUT",
+                        ]
                     },
                 },
                 {
                     "name": "ASAN",
                     "osx": {
-                        "cmd": ["sh", "Scripts/macOS/Compile.sh", "run", "debug", "asan"]
+                        "cmd": [
+                            "sh",
+                            "Scripts/macOS/Compile.sh",
+                            "run",
+                            "debug",
+                            "asan",
+                            "-DFANG_UNBUFFERED_STDOUT",
+                        ]
                     },
                 },
                 {
                     "name": "UBSAN",
                     "osx": {
-                        "cmd": ["sh", "Scripts/macOS/Compile.sh", "run", "debug", "ubsan"]
+                        "cmd": [
+                            "sh",
+                            "Scripts/macOS/Compile.sh",
+                            "run",
+                            "debug",
+                            "ubsan",
+                            "-DFANG_UNBUFFERED_STDOUT",
+                        ]
                     },
                 },
                 {
                     "name": "Release",
                     "osx": {
-                        "cmd": ["sh", "Scripts/macOS/Compile.sh", "run", "release"]
+                        "cmd": [
+                            "sh",
+                            "Scripts/macOS/Compile.sh",
+                            "run",
+                            "release",
+                            "-DFANG_UNBUFFERED_STDOUT",
+                        ]
                     },
                 },
             ]

--- a/Scripts/macOS/Compile.sh
+++ b/Scripts/macOS/Compile.sh
@@ -28,6 +28,11 @@ COMPILE_FLAGS=" "
 
 while [ "$1" != "" ]; do
     case $1 in
+        "help" )
+            echo "\$./Scripts/macOS/Compile.sh [debug|release] [asan|ubsan] [run]"
+            exit 0
+            ;;
+
         "ubsan" )
             echo "Compiling with undefined behavior sanitizer..."
             COMPILE_FLAGS+="-fsanitize=undefined "
@@ -51,9 +56,7 @@ while [ "$1" != "" ]; do
             ;;
 
         * )
-            echo "Unrecognized flag '$1'"
-            echo "\$./Scripts/macOS/Compile.sh [debug|release] [asan|ubsan] [run]"
-            exit 1
+            COMPILE_FLAGS+="$1 "
             ;;
     esac
     shift

--- a/Source/Main.c
+++ b/Source/Main.c
@@ -13,7 +13,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-int main(void)
+#include "Platform/Fang_SDL.c"
+
+int main(int argc, char **argv)
 {
-    return 0;
+    // NOTE: When building with Sublime the output panel doesn't seem to update
+    //       properly without an unbuffered stdout
+    #ifdef FANG_UNBUFFERED_STDOUT
+      setbuf(stdout, NULL);
+    #endif
+
+    return Fang_Main(argc, argv);
 }

--- a/Source/Platform/Fang_SDL.c
+++ b/Source/Platform/Fang_SDL.c
@@ -1,0 +1,99 @@
+// Copyright (C) 2021 Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+// License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include <SDL2/SDL.h>
+
+int Fang_Main(int argc, char** argv)
+{
+    (void)argc;
+    (void)argv;
+
+    {
+        SDL_version version;
+        SDL_VERSION(&version);
+        printf(
+            "SDL %d.%d.%d\n",
+            version.major,
+            version.minor,
+            version.patch
+        );
+    }
+
+    if (SDL_Init(SDL_INIT_VIDEO))
+        goto Error_SDL;
+
+    SDL_Window * const window = SDL_CreateWindow(
+        FANG_TITLE,
+        SDL_WINDOWPOS_UNDEFINED,
+        SDL_WINDOWPOS_UNDEFINED,
+        512,
+        512,
+        SDL_WINDOW_SHOWN
+            | SDL_WINDOW_ALLOW_HIGHDPI
+            | SDL_WINDOW_INPUT_FOCUS
+            | SDL_WINDOW_MOUSE_FOCUS
+    );
+
+    if (!window)
+        goto Error_Window;
+
+    SDL_Renderer * const renderer = SDL_CreateRenderer(
+        window,
+        -1,
+        SDL_RENDERER_PRESENTVSYNC
+    );
+
+    if (!renderer)
+        goto Error_Renderer;
+
+    SDL_RenderSetIntegerScale(renderer, true);
+    SDL_RenderSetLogicalSize(renderer, 512, 512);
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_NONE);
+
+    bool quit = false;
+    while (!quit)
+    {
+        SDL_Event event;
+        while (SDL_PollEvent(&event))
+        {
+            switch (event.type)
+            {
+                case SDL_QUIT:
+                    quit = true;
+                    break;
+            }
+        }
+
+        SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
+        SDL_RenderClear(renderer);
+        SDL_RenderPresent(renderer);
+    }
+
+Error_Renderer:
+    SDL_DestroyRenderer(renderer);
+
+Error_Window:
+    SDL_DestroyWindow(window);
+
+Error_SDL:
+    puts(SDL_GetError());
+    SDL_ClearError();
+    SDL_Quit();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Description

Adding the SDL platform initialization, along with fixing an issue when running builds through Sublime.

## Changes
- Add `Platform/Fang_SDL.c` and SDL initialization with window and renderer
- Update `Fang.sublime-project` to define `FANG_UNBUFFERED_STDOUT`
- Add `help` argument to `Scripts/macOS/Compile.sh`
