### PR TITLE
Add Basics For Software Rendering

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -13,17 +13,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-const int FANG_WINDOW_SIZE = 512;
+#include "Fang_Color.c"
+#include "Fang_Rect.c"
+#include "Fang_Image.c"
+#include "Fang_Framebuffer.c"
+#include "Fang_Render.c"
 
-#include "Platform/Fang_SDL.c"
-
-int main(int argc, char **argv)
+static inline void
+Fang_UpdateAndRender(
+    Fang_Framebuffer * const framebuf)
 {
-    // NOTE: When building with Sublime the output panel doesn't seem to update
-    //       properly without an unbuffered stdout
-    #ifdef FANG_UNBUFFERED_STDOUT
-      setbuf(stdout, NULL);
-    #endif
+    assert(framebuf);
 
-    return Fang_Main(argc, argv);
+    Fang_FramebufferClear(framebuf);
 }

--- a/Source/Fang/Fang_Color.c
+++ b/Source/Fang/Fang_Color.c
@@ -1,0 +1,44 @@
+// Copyright (C) 2021 Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+// License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+typedef struct Fang_Color {
+    uint8_t r, g, b, a;
+} Fang_Color;
+
+const Fang_Color FANG_RED    = {255,   0,   0, 255};
+const Fang_Color FANG_ORANGE = {255, 128,   0, 255};
+const Fang_Color FANG_YELLOW = {255, 255,   0, 255};
+const Fang_Color FANG_GREEN  = {  0, 255,   0, 255};
+const Fang_Color FANG_BLUE   = {  0,   0, 255, 255};
+const Fang_Color FANG_PURPLE = {128,   0, 255, 255};
+const Fang_Color FANG_WHITE  = {255, 255, 255, 255};
+const Fang_Color FANG_BLACK  = {  0,   0,   0, 255};
+
+/**
+ * @brief Maps RGBA components of a Fang_Color to a 32-bit, unsigned integer.
+**/
+static inline uint32_t
+Fang_MapColor(
+    const Fang_Color * const color)
+{
+    assert(color);
+
+    return (
+        (uint32_t)color->r << 24
+      | (uint32_t)color->g << 16
+      | (uint32_t)color->b << 8
+      | (uint32_t)color->a
+    );
+}

--- a/Source/Fang/Fang_Framebuffer.c
+++ b/Source/Fang/Fang_Framebuffer.c
@@ -1,0 +1,113 @@
+// Copyright (C) 2021 Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+// License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A structure used for rendering to the screen.
+ *
+ * Framebuffers consist of two images:
+ * - A color image whose result is drawn to the screen
+ * - A stencil buffer used internally to discard pixels
+ *
+ * @see Fang_FramebufferPutPixel()
+**/
+typedef struct Fang_Framebuffer
+{
+    Fang_Image color;
+    Fang_Image stencil;
+    bool       enable_stencil;
+} Fang_Framebuffer;
+
+/**
+ * @brief Writes a pixel of a given color to the framebuffer.
+ *
+ * This routine utilizes the framebuffer's stencil when placing pixels. If the
+ * stencil is enabled, its buffer is checked to see if a value has already been
+ * written in this position.
+ *
+ * If a value has been written, we do not write the new pixel into the color
+ * image. If a value has not been written then the stencil is written to and the
+ * color is written into the color image. If the point lies outside the
+ * framebuffer bounds this function does nothing.
+ *
+ * The framebuffer must have a color image.
+**/
+static inline bool
+Fang_FramebufferPutPixel(
+    const Fang_Framebuffer * const framebuf,
+    const Fang_Point       * const point,
+    const Fang_Color       * const color)
+{
+    assert(framebuf);
+    assert(framebuf->color.pixels);
+
+    if (point->x < 0 || point->x >= framebuf->color.width)
+        return false;
+
+    if (point->y < 0 || point->y >= framebuf->color.height)
+        return false;
+
+    bool write = true;
+
+    if (framebuf->enable_stencil)
+    {
+        assert(framebuf->stencil.pixels);
+        assert(framebuf->stencil.width  == framebuf->color.width);
+        assert(framebuf->stencil.height == framebuf->color.height);
+        assert(framebuf->stencil.pitch  == framebuf->stencil.width);
+
+        const uint8_t pixel  = UINT8_MAX;
+        const int     offset = (
+            point->y * framebuf->stencil.pitch
+          + point->x * framebuf->stencil.stride
+        );
+
+        if (*(framebuf->stencil.pixels + offset))
+            write = false;
+        else
+            *(framebuf->stencil.pixels + offset) = pixel;
+    }
+
+    if (write)
+    {
+        const uint32_t pixel  = Fang_MapColor(color);
+        const int      offset = (
+            point->y * framebuf->color.pitch
+          + point->x * framebuf->color.stride
+        );
+
+        *(uint32_t*)(framebuf->color.pixels + offset) = pixel;
+    }
+
+    return write;
+}
+
+/**
+ * @brief Clear's the framebuffer's color and stencil images.
+ *
+ * If the framebuffer does not have a stencil image, only the color is cleared.
+ * The framebuffer must have a color image.
+**/
+static inline void
+Fang_FramebufferClear(
+    Fang_Framebuffer * const framebuf)
+{
+    assert(framebuf);
+    assert(framebuf.color->pixels);
+
+    Fang_ImageClear(&framebuf->color);
+
+    if (framebuf->stencil.pixels)
+        Fang_ImageClear(&framebuf->stencil);
+}

--- a/Source/Fang/Fang_Image.c
+++ b/Source/Fang/Fang_Image.c
@@ -13,17 +13,32 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-const int FANG_WINDOW_SIZE = 512;
+typedef struct Fang_Image {
+    uint8_t * pixels;
+    int       width;
+    int       height;
+    int       pitch;
+    int       stride;
+} Fang_Image;
 
-#include "Platform/Fang_SDL.c"
-
-int main(int argc, char **argv)
+/**
+ * @brief Clears the pixel data for the given image.
+ *
+ * This resets all values in the pixel buffer to 0, meaning the alpha values are
+ * not preserved nor reset to 255 during this operation.
+ *
+ * The image must have a valid pixel data pointer.
+**/
+static inline void
+Fang_ImageClear(
+    Fang_Image * const image)
 {
-    // NOTE: When building with Sublime the output panel doesn't seem to update
-    //       properly without an unbuffered stdout
-    #ifdef FANG_UNBUFFERED_STDOUT
-      setbuf(stdout, NULL);
-    #endif
+    assert(image);
+    assert(image->pixels);
 
-    return Fang_Main(argc, argv);
+    memset(
+        (void*)image->pixels,
+        0,
+        image->height * image->pitch + image->width * image->stride
+    );
 }

--- a/Source/Fang/Fang_Rect.c
+++ b/Source/Fang/Fang_Rect.c
@@ -13,17 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-const int FANG_WINDOW_SIZE = 512;
+typedef struct Fang_Point {
+    int x, y;
+} Fang_Point;
 
-#include "Platform/Fang_SDL.c"
-
-int main(int argc, char **argv)
-{
-    // NOTE: When building with Sublime the output panel doesn't seem to update
-    //       properly without an unbuffered stdout
-    #ifdef FANG_UNBUFFERED_STDOUT
-      setbuf(stdout, NULL);
-    #endif
-
-    return Fang_Main(argc, argv);
-}
+typedef struct Fang_Rect {
+    int x, y, w, h;
+} Fang_Rect;

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -1,0 +1,136 @@
+// Copyright (C) 2021 Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+// License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @brief Draws a line in the framebuffer using Bresenham's Algorithm.
+ *
+ * @param framebuf the target framebuffer, must have color image
+ * @param start    the beginning point of the line
+ * @param end      the ending point of the line
+ * @param color    the color of the line
+**/
+static void
+Fang_DrawLine(
+          Fang_Framebuffer * const framebuf,
+    const Fang_Point       * const start,
+    const Fang_Point       * const end,
+    const Fang_Color       * const color)
+{
+    assert(framebuf);
+    assert(start);
+    assert(end);
+    assert(color);
+
+    const Fang_Point delta = {
+        .x =  abs(end->x - start->x),
+        .y = -abs(end->y - start->y),
+    };
+
+    const Fang_Point step = {
+        .x = (start->x < end->x) ? 1 : (start->x > end->x) ? -1 : 0,
+        .y = (start->y < end->y) ? 1 : (start->y > end->y) ? -1 : 0,
+    };
+
+    Fang_Point point = *start;
+    int        err   = delta.x + delta.y;
+
+    while (true)
+    {
+        Fang_FramebufferPutPixel(framebuf, &point, color);
+
+        if ((err * 2) >= delta.y)
+        {
+            if (point.x == end->x)
+                break;
+
+            err     += delta.y;
+            point.x += step.x;
+        }
+
+        if ((err * 2) <= delta.x)
+        {
+            if (point.y == end->y)
+                break;
+
+            err     += delta.x;
+            point.y += step.y;
+        }
+    }
+}
+
+/**
+ * @brief Draws a 1px thick outline of a rectangle in the framebuffer.
+ *
+ * @param framebuf the target framebuffer, must have color image
+ * @param rect     the rectangle to draw
+ * @param color    the color of the rectangle
+**/
+static void
+Fang_DrawRect(
+          Fang_Framebuffer * const framebuf,
+    const Fang_Rect        * const rect,
+    const Fang_Color       * const color)
+{
+    assert(framebuf);
+    assert(rect);
+    assert(color);
+
+    for (int h = 0; h < rect->h; h += rect->h - 1)
+    {
+        for (int w = 0; w < rect->w; ++w)
+        {
+            Fang_FramebufferPutPixel(
+                framebuf, &(Fang_Point){rect->x + w, rect->y + h}, color
+            );
+        }
+    }
+
+    for (int h = 0; h < rect->h; ++h)
+    {
+        for (int w = 0; w < rect->w; w += rect->w - 1)
+        {
+            Fang_FramebufferPutPixel(
+                framebuf, &(Fang_Point){rect->x + w, rect->y + h}, color
+            );
+        }
+    }
+}
+
+/** @brief Draws a solid rectangle in the framebuffer.
+ *
+ * @param framebuf the target framebuffer, must have color image
+ * @param rect     the rectangle to draw
+ * @param color    the color of the rectangle
+**/
+static void
+Fang_FillRect(
+          Fang_Framebuffer * const framebuf,
+    const Fang_Rect        * const rect,
+    const Fang_Color       * const color)
+{
+    assert(framebuf);
+    assert(rect);
+    assert(color);
+
+    for (int h = 0; h < rect->h; ++h)
+    {
+        for (int w = 0; w < rect->w; ++w)
+        {
+            Fang_FramebufferPutPixel(
+                framebuf, &(Fang_Point){rect->x + w, rect->y + h}, color
+            );
+        }
+    }
+}


### PR DESCRIPTION
Resolves #5 

## Description

Implementing some basic objects and functions for the game's software renderer, including an initial pass at stencil testing.

## Changes

- Adds `Fang_Point`, `Fang_Rect`, `Fang_Color`, `Fang_Image`, and `Fang_Framebuffer` structs for use with the software renderer
- Adds rendering functions for drawing points, lines, rectangles, and filled rectangles
- Implements basic support for stencil testing when writing to framebuffers
- Adds main `Fang.c` file that contains the "update and render" function that the platform layer is responsible for calling
- Adds `FANG_WINDOW_SIZE` constant to keep window/texture/framebuffer sizes synced easily for now
- Updates platform-layer renderer to create texture that serves as the game's render target 
