### PR TITLE
Implement Basic Input Handling

### DIFF
--- a/Scripts/macOS/Compile.sh
+++ b/Scripts/macOS/Compile.sh
@@ -80,6 +80,7 @@ if test $RELEASE -eq 1; then
     DIR_BUILD+="/Release"
 else
     COMPILE_FLAGS+="-g "
+    COMPILE_FLAGS+="-Wno-unused-function "
     DIR_BUILD+="/Debug"
 fi
 
@@ -115,11 +116,7 @@ cc \
     "Source/Main.c"
 
 if test $DEBUG -eq 1; then
-    echo "Launching debugger..."
     lldb -o run "./$BINARY"
 elif test $RUN -eq 1; then
-    echo "Launching game..."
     "./$BINARY"
 fi
-
-echo "Done"

--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -15,14 +15,17 @@
 
 #include "Fang_Color.c"
 #include "Fang_Rect.c"
+#include "Fang_Input.c"
 #include "Fang_Image.c"
 #include "Fang_Framebuffer.c"
 #include "Fang_Render.c"
 
 static inline void
 Fang_UpdateAndRender(
-    Fang_Framebuffer * const framebuf)
+    const Fang_Input       * const input,
+          Fang_Framebuffer * const framebuf)
 {
+    assert(input);
     assert(framebuf);
 
     Fang_FramebufferClear(framebuf);

--- a/Source/Fang/Fang_Framebuffer.c
+++ b/Source/Fang/Fang_Framebuffer.c
@@ -104,7 +104,7 @@ Fang_FramebufferClear(
     Fang_Framebuffer * const framebuf)
 {
     assert(framebuf);
-    assert(framebuf.color->pixels);
+    assert(framebuf->color.pixels);
 
     Fang_ImageClear(&framebuf->color);
 

--- a/Source/Fang/Fang_Input.c
+++ b/Source/Fang/Fang_Input.c
@@ -1,0 +1,172 @@
+// Copyright (C) 2021 Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+// License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A simple input button.
+ *
+ * To facilitate actions like double-tapping a button, the number of state
+ * transitions (i.e. movements from 0 -> 1 or vice versa) is saved with the
+ * button. This is separate from whether the button is currently being pressed.
+**/
+typedef struct Fang_InputButton {
+    bool pressed;
+    int  transitions;
+} Fang_InputButton;
+
+/**
+ * A dual-axis analog stick with an additional button.
+ *
+ * This assumes that the user can press the joystick inwards to activate an
+ * additional button. If no such button exists on the user's controller this
+ * functionality is ignored.
+**/
+typedef struct Fang_InputJoystick {
+    float x, y;
+    Fang_InputButton button;
+} Fang_InputJoystick;
+
+/**
+ * A mouse input device.
+ *
+ * This will be directly tied to an actual, physical mouse. It may be a tracked
+ * mouse or a touchpad (though actual touch gestures are not supported). If a
+ * mouse is not connected this functionality is ignored.
+**/
+typedef struct Fang_InputMouse {
+    Fang_InputButton left;
+    Fang_InputButton right;
+    Fang_InputButton middle;
+    Fang_Point       position;
+    Fang_Point       relative;
+} Fang_InputMouse;
+
+/**
+ * A game controller input device.
+ *
+ * This can either be an actual, connected gamepad, or it could be the keyboard.
+ * The platform layer handles mapping the keyboard keys to the appropriate
+ * attributes of the controller.
+ *
+ * Note that since keyboard keys cannot have analog representations, holding
+ * down a key will set its analog input to either -1.0f or 1.0f with no
+ * in-between.
+**/
+typedef struct Fang_InputController {
+    Fang_InputButton start;
+    Fang_InputButton back;
+
+    Fang_InputJoystick joystick_left;
+    Fang_InputJoystick joystick_right;
+
+    float trigger_left;
+    float trigger_right;
+    Fang_InputButton   shoulder_left;
+    Fang_InputButton   shoulder_right;
+
+    Fang_InputButton direction_up;
+    Fang_InputButton direction_down;
+    Fang_InputButton direction_left;
+    Fang_InputButton direction_right;
+
+    Fang_InputButton action_up;
+    Fang_InputButton action_down;
+    Fang_InputButton action_left;
+    Fang_InputButton action_right;
+} Fang_InputController;
+
+/**
+ * The modes that the text-input state may be in.
+**/
+typedef enum Fang_InputTextMode {
+    FANG_INPUTTEXT_INACTIVE,
+    FANG_INPUTTEXT_TYPING,
+    FANG_INPUTTEXT_EDITING,
+} Fang_InputTextMode;
+
+/**
+ * A structure representing a text input event.
+ *
+ * If the active attribute is true, then the following attributes will represent
+ * the user's text entry or editing (the text entered, the cursor position,
+ * and a selection length). The cursor and length values will only be valid
+ * during editing.
+**/
+typedef struct Fang_InputText {
+    int32_t cursor;
+    int32_t length;
+    char    text[32];
+    Fang_InputTextMode mode;
+} Fang_InputText;
+
+/**
+ * A structure representing the input state for a given frame.
+ *
+ * @see Fang_InputClear()
+**/
+typedef struct Fang_Input {
+    Fang_InputText       text;
+    Fang_InputMouse      mouse;
+    Fang_InputController controller;
+} Fang_Input;
+
+/**
+ * @brief Returns whether the button was pressed during the frame.
+**/
+static inline bool
+Fang_InputWasPressed(
+    Fang_InputButton * const button)
+{
+    assert(button);
+
+    if (button->transitions > 1)
+        return true;
+
+    return button->transitions == 1 && button->pressed;
+}
+
+/**
+ * @brief Resets the transition counts and relative positions for the inputs.
+ *
+ * Buttons and relative positions (such as for the mouse) will be reset back to
+ * 0, but analog values will remain the same. This function should be called
+ * once per frame before handling OS input events.
+ *
+ * This function will also reset the input's text mode back to
+ * FANG_INPUTTEXT_INACTIVE. It will not clear the text that is already in the
+ * text buffer.
+**/
+static void
+Fang_InputReset(
+    Fang_Input * const input)
+{
+    assert(input);
+
+    input->controller.start.transitions = 0;
+    input->controller.back.transitions = 0;
+    input->controller.joystick_left.button.transitions = 0;
+    input->controller.joystick_right.button.transitions = 0;
+    input->controller.shoulder_left.transitions = 0;
+    input->controller.shoulder_right.transitions = 0;
+    input->controller.direction_up.transitions = 0;
+    input->controller.direction_down.transitions = 0;
+    input->controller.direction_left.transitions = 0;
+    input->controller.direction_right.transitions = 0;
+    input->controller.action_up.transitions = 0;
+    input->controller.action_down.transitions = 0;
+    input->controller.action_left.transitions = 0;
+    input->controller.action_right.transitions = 0;
+
+    input->text.mode = FANG_INPUTTEXT_INACTIVE;
+}

--- a/Source/Platform/Fang_SDL.c
+++ b/Source/Platform/Fang_SDL.c
@@ -23,6 +23,41 @@
 
 #include "../Fang/Fang.c"
 
+static inline void
+FangSDL_ConnectController(
+    SDL_GameController ** const controller)
+{
+    SDL_assert(controller);
+
+    if (*controller && SDL_GameControllerGetAttached(*controller))
+        SDL_GameControllerClose(*controller);
+
+    const int id = SDL_NumJoysticks() - 1;
+
+    if (id < 0)
+        return;
+
+    if (!SDL_IsGameController(id))
+        return;
+
+    *controller = SDL_GameControllerOpen(id);
+}
+
+static inline void
+FangSDL_DisconnectController(
+    SDL_GameController ** const controller)
+{
+    SDL_assert(controller);
+
+    if (!*controller)
+        return;
+
+    if (SDL_GameControllerGetAttached(*controller))
+        SDL_GameControllerClose(*controller);
+
+    *controller = NULL;
+}
+
 int Fang_Main(int argc, char** argv)
 {
     (void)argc;
@@ -39,8 +74,10 @@ int Fang_Main(int argc, char** argv)
         );
     }
 
-    if (SDL_Init(SDL_INIT_VIDEO))
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER))
         goto Error_SDL;
+
+    SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
 
     SDL_Window * const window = SDL_CreateWindow(
         FANG_TITLE,
@@ -77,21 +114,208 @@ int Fang_Main(int argc, char** argv)
     if (!texture)
         goto Error_Texture;
 
+    SDL_GameController * controller = NULL;
+    FangSDL_ConnectController(&controller);
+
     SDL_RenderSetIntegerScale(renderer, true);
     SDL_RenderSetLogicalSize(renderer, FANG_WINDOW_SIZE, FANG_WINDOW_SIZE);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_NONE);
 
+    SDL_JoystickEventState(SDL_ENABLE);
+    SDL_GameControllerEventState(SDL_ENABLE);
+
+    SDL_RaiseWindow(window);
+
+    Fang_Input input;
+    SDL_memset(&input, 0, sizeof(Fang_Input));
+
     bool quit = false;
     while (!quit)
     {
+        Fang_InputReset(&input);
+
         SDL_Event event;
         while (SDL_PollEvent(&event))
         {
             switch (event.type)
             {
                 case SDL_QUIT:
+                {
                     quit = true;
                     break;
+                }
+
+                case SDL_JOYDEVICEADDED:
+                {
+                    FangSDL_ConnectController(&controller);
+                    break;
+                }
+
+                case SDL_JOYDEVICEREMOVED:
+                {
+                    FangSDL_DisconnectController(&controller);
+                    break;
+                }
+
+                case SDL_CONTROLLERAXISMOTION:
+                {
+                    const float min_axis = (float)INT16_MIN;
+                    const float max_axis = (float)INT16_MAX;
+
+                    float axis = (event.caxis.value - min_axis)
+                               / (max_axis - min_axis);
+
+                    axis = 2.0f * axis - 1.0f;
+
+                    if (fabsf(axis) <= 0.1f)
+                        axis = 0.0f;
+
+                    const SDL_GameControllerAxis type = event.caxis.axis;
+                    if (type == SDL_CONTROLLER_AXIS_LEFTX)
+                        input.controller.joystick_left.x = axis;
+                    else if (type == SDL_CONTROLLER_AXIS_LEFTY)
+                        input.controller.joystick_left.y = axis;
+                    else if (type == SDL_CONTROLLER_AXIS_RIGHTX)
+                        input.controller.joystick_right.x = axis;
+                    else if (type == SDL_CONTROLLER_AXIS_RIGHTY)
+                        input.controller.joystick_right.y = axis;
+                    else if (type == SDL_CONTROLLER_AXIS_TRIGGERLEFT)
+                        input.controller.trigger_left = axis;
+                    else if (type == SDL_CONTROLLER_AXIS_TRIGGERRIGHT)
+                        input.controller.trigger_right = axis;
+
+                    break;
+                }
+
+                case SDL_CONTROLLERBUTTONDOWN:
+                case SDL_CONTROLLERBUTTONUP:
+                {
+                    Fang_InputButton * button = NULL;
+
+                    const SDL_GameControllerButton type = event.cbutton.button;
+                    if (type == SDL_CONTROLLER_BUTTON_START)
+                        button = &input.controller.start;
+                    else if (type == SDL_CONTROLLER_BUTTON_BACK)
+                        button = &input.controller.back;
+                    else if (type == SDL_CONTROLLER_BUTTON_LEFTSTICK)
+                        button = &input.controller.joystick_left.button;
+                    else if (type == SDL_CONTROLLER_BUTTON_RIGHTSTICK)
+                        button = &input.controller.joystick_right.button;
+                    else if (type == SDL_CONTROLLER_BUTTON_DPAD_UP)
+                        button = &input.controller.direction_up;
+                    else if (type == SDL_CONTROLLER_BUTTON_DPAD_DOWN)
+                        button = &input.controller.direction_down;
+                    else if (type == SDL_CONTROLLER_BUTTON_DPAD_LEFT)
+                        button = &input.controller.direction_left;
+                    else if (type == SDL_CONTROLLER_BUTTON_DPAD_RIGHT)
+                        button = &input.controller.direction_right;
+                    else if (type == SDL_CONTROLLER_BUTTON_Y)
+                        button = &input.controller.action_up;
+                    else if (type == SDL_CONTROLLER_BUTTON_A)
+                        button = &input.controller.action_down;
+                    else if (type == SDL_CONTROLLER_BUTTON_X)
+                        button = &input.controller.action_left;
+                    else if (type == SDL_CONTROLLER_BUTTON_B)
+                        button = &input.controller.action_right;
+                    else if (type == SDL_CONTROLLER_BUTTON_LEFTSHOULDER)
+                        button = &input.controller.shoulder_left;
+                    else if (type == SDL_CONTROLLER_BUTTON_RIGHTSHOULDER)
+                        button = &input.controller.shoulder_right;
+
+                    if (button)
+                    {
+                        button->transitions++;
+                        button->pressed = (event.cbutton.state == SDL_PRESSED);
+                    }
+
+                    break;
+                }
+
+                case SDL_MOUSEMOTION:
+                {
+                    input.mouse.position.x = event.motion.x;
+                    input.mouse.position.y = event.motion.y;
+                    input.mouse.relative.x = event.motion.xrel;
+                    input.mouse.relative.y = event.motion.yrel;
+                    break;
+                }
+
+                case SDL_MOUSEBUTTONDOWN:
+                case SDL_MOUSEBUTTONUP:
+                {
+                    Fang_InputButton * button = NULL;
+
+                    const uint8_t type = event.button.button;
+                    if (type == SDL_BUTTON_LEFT)
+                        button = &input.mouse.left;
+                    else if (type == SDL_BUTTON_MIDDLE)
+                        button = &input.mouse.middle;
+                    else if (type == SDL_BUTTON_RIGHT)
+                        button = &input.mouse.right;
+
+                    if (button)
+                    {
+                        button->transitions = event.button.clicks;
+                        button->pressed = (event.button.state == SDL_PRESSED);
+                    }
+
+                    input.mouse.position.x = event.button.x;
+                    input.mouse.position.y = event.button.y;
+                    break;
+                }
+
+                case SDL_KEYDOWN:
+                case SDL_KEYUP:
+                {
+                    if (event.key.repeat)
+                        break;
+
+                    Fang_InputButton * button = NULL;
+
+                    SDL_Keycode sym = event.key.keysym.sym;
+                    if (sym == SDLK_w)
+                        button = &input.controller.direction_up;
+                    else if (sym == SDLK_s)
+                        button = &input.controller.direction_down;
+                    else if (sym == SDLK_a)
+                        button = &input.controller.direction_left;
+                    else if (sym == SDLK_d)
+                        button = &input.controller.direction_right;
+
+                    if (button)
+                    {
+                        button->transitions++;
+                        button->pressed = (event.key.state == SDL_PRESSED);
+                    }
+
+                    break;
+                }
+
+                case SDL_TEXTINPUT:
+                {
+                    input.text.mode = FANG_INPUTTEXT_TYPING;
+                    input.text.cursor = 0;
+                    input.text.length = 0;
+                    SDL_memcpy(
+                        input.text.text,
+                        event.text.text,
+                        sizeof(char[32])
+                    );
+                    break;
+                }
+
+                case SDL_TEXTEDITING:
+                {
+                    input.text.mode = FANG_INPUTTEXT_EDITING;
+                    input.text.cursor = event.edit.start;
+                    input.text.length = event.edit.length;
+                    SDL_memcpy(
+                        input.text.text,
+                        event.edit.text,
+                        sizeof(char[32])
+                    );
+                    break;
+                }
             }
         }
 
@@ -114,7 +338,7 @@ int Fang_Main(int argc, char** argv)
             if (error)
                 break;
 
-            Fang_UpdateAndRender(&framebuf);
+            Fang_UpdateAndRender(&input, &framebuf);
             SDL_UnlockTexture(texture);
         }
 
@@ -122,6 +346,8 @@ int Fang_Main(int argc, char** argv)
         SDL_RenderCopy(renderer, texture, NULL, NULL);
         SDL_RenderPresent(renderer);
     }
+
+    FangSDL_DisconnectController(&controller);
 
 Error_Texture:
     SDL_DestroyTexture(texture);


### PR DESCRIPTION
Resolves #4 

## Description

Adding support for input handling (controller, keyboard + mouse).

Currently there are a few things to note:
- Only one controller can be connected at a time (any previous gets disconnected)
- Both the controller and keyboard + mouse send input to the game
- Keyboard mappings are hard-coded into the platform layer; currently only supports mapping WASD to controller D-pad

## Changes
- Adds new structures and functions for input controls
- Adds input mapping to the platform layer
- Updates `Fang_UpdateAndRender()` to take the new input struct
- Fixes a de-referencing typo in `Fang_Framebuffer.c`
- Updates build script to remove extra echoes
- Disables "unused function" warnings when not making a release build

