### PR TITLE
Add Basic Immediate-Mode UI

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -19,6 +19,9 @@
 #include "Fang_Image.c"
 #include "Fang_Framebuffer.c"
 #include "Fang_Render.c"
+#include "Fang_Interface.c"
+
+Fang_Interface interface;
 
 static inline void
 Fang_UpdateAndRender(
@@ -27,6 +30,10 @@ Fang_UpdateAndRender(
 {
     assert(input);
     assert(framebuf);
+
+    interface.input    = input;
+    interface.framebuf = framebuf;
+    Fang_InterfaceUpdate(&interface);
 
     Fang_FramebufferClear(framebuf);
 }

--- a/Source/Fang/Fang_Color.c
+++ b/Source/Fang/Fang_Color.c
@@ -24,10 +24,11 @@ const Fang_Color FANG_GREEN  = {  0, 255,   0, 255};
 const Fang_Color FANG_BLUE   = {  0,   0, 255, 255};
 const Fang_Color FANG_PURPLE = {128,   0, 255, 255};
 const Fang_Color FANG_WHITE  = {255, 255, 255, 255};
+const Fang_Color FANG_GREY   = {128, 128, 128, 255};
 const Fang_Color FANG_BLACK  = {  0,   0,   0, 255};
 
 /**
- * @brief Maps RGBA components of a Fang_Color to a 32-bit, unsigned integer.
+ * Maps RGBA components of a Fang_Color to a 32-bit, unsigned integer.
 **/
 static inline uint32_t
 Fang_MapColor(

--- a/Source/Fang/Fang_Framebuffer.c
+++ b/Source/Fang/Fang_Framebuffer.c
@@ -30,7 +30,7 @@ typedef struct Fang_Framebuffer
 } Fang_Framebuffer;
 
 /**
- * @brief Writes a pixel of a given color to the framebuffer.
+ * Writes a pixel of a given color to the framebuffer.
  *
  * This routine utilizes the framebuffer's stencil when placing pixels. If the
  * stencil is enabled, its buffer is checked to see if a value has already been
@@ -94,7 +94,7 @@ Fang_FramebufferPutPixel(
 }
 
 /**
- * @brief Clear's the framebuffer's color and stencil images.
+ * Clear's the framebuffer's color and stencil images.
  *
  * If the framebuffer does not have a stencil image, only the color is cleared.
  * The framebuffer must have a color image.

--- a/Source/Fang/Fang_Image.c
+++ b/Source/Fang/Fang_Image.c
@@ -22,7 +22,7 @@ typedef struct Fang_Image {
 } Fang_Image;
 
 /**
- * @brief Clears the pixel data for the given image.
+ * Clears the pixel data for the given image.
  *
  * This resets all values in the pixel buffer to 0, meaning the alpha values are
  * not preserved nor reset to 255 during this operation.

--- a/Source/Fang/Fang_Input.c
+++ b/Source/Fang/Fang_Input.c
@@ -122,22 +122,29 @@ typedef struct Fang_Input {
 } Fang_Input;
 
 /**
- * @brief Returns whether the button was pressed during the frame.
+ * Returns whether the button was pressed during the frame.
 **/
 static inline bool
-Fang_InputWasPressed(
-    Fang_InputButton * const button)
+Fang_InputPressed(
+    const Fang_InputButton * const button)
 {
     assert(button);
-
-    if (button->transitions > 1)
-        return true;
-
-    return button->transitions == 1 && button->pressed;
+    return button->pressed && button->transitions;
 }
 
 /**
- * @brief Resets the transition counts and relative positions for the inputs.
+ * Returns whether the button was released during the frame.
+**/
+static inline bool
+Fang_InputReleased(
+    const Fang_InputButton * const button)
+{
+    assert(button);
+    return !button->pressed && button->transitions;
+}
+
+/**
+ * Resets the transition counts and relative positions for the inputs.
  *
  * Buttons and relative positions (such as for the mouse) will be reset back to
  * 0, but analog values will remain the same. This function should be called

--- a/Source/Fang/Fang_Interface.c
+++ b/Source/Fang/Fang_Interface.c
@@ -1,0 +1,233 @@
+// Copyright (C) 2021 Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+// License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This interface state holds the identifiers used for the immediate-mode,
+ * graphical user interface elements.
+ *
+ * The id acts as a counter that the IMGUI functions can use to assign
+ * themselves an id number. This id number is then compared against the hot,
+ * next, and active attributes so the element can decide how it should handle
+ * user interaction.
+ *
+ * If an element is the 'active' item, it has full control and focus from the
+ * user. Any interaction that occurs should be considered to be for that given
+ * UI element during this frame. For example, if button were the active item it
+ * would mean a mouse-release event in that frame end a 'click' for button.
+ *
+ * The 'hot' item is the item who has user focus but is not currently being
+ * interacted with. To take the previous example, if a mouse-down event happened
+ * on a 'hot' button then it would begin a 'click' for the button. However, as
+ * noted before, the click would not 'complete' until the button was active and
+ * received a mouse-up.
+ *
+ * The 'next' item is the item who is trying to gain user focus. For our example
+ * button, it would set itself to the 'next' item if the mouse was within its
+ * bounds. In the following frame - if no other element tried to claim 'next' -
+ * the button would become the 'hot' item.
+**/
+typedef struct Fang_Interface {
+    uint32_t id;
+    uint32_t hot;
+    uint32_t next;
+    uint32_t active;
+
+    Fang_Framebuffer * framebuf;
+    const Fang_Input * input;
+} Fang_Interface;
+
+/**
+ * Sets the interface object up for a new frame.
+ *
+ * The current 'next' item will become the 'hot' item, and the 'next' item will
+ * be set to 0. The 'id' will also be set to 0.
+ *
+ * This should be called at the beginning of each frame.
+**/
+static inline void
+Fang_InterfaceUpdate(
+    Fang_Interface * const interface)
+{
+    assert(interface);
+    interface->hot = interface->next;
+    interface->id   = 0;
+    interface->next = 0;
+}
+
+/**
+ * Resets all the interface item states back to 0.
+ *
+ * This should be called when interfaces change, such as moving to a different
+ * menu or changing scenes in the game.
+**/
+static inline void
+Fang_InterfaceReset(
+    Fang_Interface * const interface)
+{
+    assert(interface);
+    memset(interface, 0, sizeof(Fang_Interface));
+}
+
+static inline bool
+Fang_InterfaceButton(
+          Fang_Interface * const interface,
+    const Fang_Rect      * const bounds,
+    const Fang_Color     * const color)
+{
+    assert(interface);
+    assert(bounds);
+    assert(color);
+
+    const uint32_t id = ++interface->id;
+
+    bool result = false;
+
+    {
+        const Fang_Input * const input = interface->input;
+        assert(input);
+
+        const bool hot    = interface->hot    == id;
+        const bool active = interface->active == id;
+
+        if (active)
+        {
+            if (Fang_InputReleased(&input->mouse.left)
+            ||  Fang_InputReleased(&input->controller.action_down))
+            {
+                if (hot)
+                    result = true;
+
+                interface->active = 0;
+            }
+        }
+        else if (hot)
+        {
+            if (Fang_InputPressed(&input->mouse.left)
+            ||  Fang_InputPressed(&input->controller.action_down))
+                interface->active = id;
+        }
+
+        if (Fang_RectContains(bounds, &input->mouse.position))
+            interface->next = id;
+    }
+
+    {
+        Fang_Framebuffer * const framebuf = interface->framebuf;
+        assert(framebuf);
+
+        const bool hot    = interface->hot    == id;
+        const bool active = interface->active == id;
+
+        if (active)
+            Fang_FillRect(framebuf, bounds, color);
+        else if (hot)
+            Fang_DrawRect(framebuf, bounds, color);
+        else
+            Fang_DrawRect(framebuf, bounds, &FANG_GREY);
+    }
+
+    return result;
+}
+
+static inline bool
+Fang_InterfaceSlider(
+          Fang_Interface * const interface,
+          float          * const value,
+    const Fang_Rect      * const bounds,
+    const Fang_Color     * const color)
+{
+    assert(interface);
+    assert(bounds);
+    assert(color);
+
+    const uint32_t id = ++interface->id;
+
+    bool result = false;
+
+    {
+        const Fang_Input * const input = interface->input;
+        assert(input);
+
+        const bool hot    = interface->hot    == id;
+        const bool active = interface->active == id;
+
+        if (active)
+        {
+            if (Fang_InputReleased(&input->mouse.left)
+            ||  Fang_InputReleased(&input->controller.action_down))
+            {
+                interface->active = 0;
+            }
+            else
+            {
+                result = true;
+
+                const int left     = bounds->x;
+                const int right    = bounds->x + bounds->w;
+                const int position = input->mouse.position.x;
+
+                if (position <= left)
+                {
+                    *value = 0.0f;
+                }
+                else if (position >= right)
+                {
+                    *value = 1.0f;
+                }
+                else
+                {
+                    *value = (float)(position - left)
+                           / (float)(right - left);
+                }
+            }
+        }
+        else if (hot)
+        {
+            if (Fang_InputPressed(&input->mouse.left)
+            ||  Fang_InputPressed(&input->controller.action_down))
+                interface->active = id;
+        }
+
+        if (Fang_RectContains(bounds, &input->mouse.position))
+            interface->next = id;
+    }
+
+    {
+        Fang_Framebuffer * const framebuf = interface->framebuf;
+        assert(framebuf);
+
+        const bool hot    = interface->hot    == id;
+        const bool active = interface->active == id;
+
+        Fang_DrawRect(
+            framebuf,
+            bounds,
+            (active || hot) ? color : &FANG_GREY
+        );
+
+        Fang_FillRect(
+            framebuf,
+            &(Fang_Rect){
+                .x = 1,
+                .y = 1,
+                .w = (int)roundf((bounds->w - 1) * (*value)),
+                .h = bounds->h - 1,
+            },
+            (active || hot) ? color : &FANG_GREY
+        );
+    }
+
+    return result;
+}

--- a/Source/Fang/Fang_Rect.c
+++ b/Source/Fang/Fang_Rect.c
@@ -20,3 +20,22 @@ typedef struct Fang_Point {
 typedef struct Fang_Rect {
     int x, y, w, h;
 } Fang_Rect;
+
+/**
+ * Returns whether or not a point lies within a given area.
+**/
+static inline bool
+Fang_RectContains(
+    const Fang_Rect  * const rect,
+    const Fang_Point * const point)
+{
+    assert(rect);
+    assert(point);
+
+    return (
+        point->x >= rect->x
+     && point->x <= rect->x + rect->w
+     && point->y >= rect->y
+     && point->y <= rect->y + rect->h
+    );
+}

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -14,12 +14,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * @brief Draws a line in the framebuffer using Bresenham's Algorithm.
+ * Draws a line in the framebuffer using Bresenham's Algorithm.
  *
- * @param framebuf the target framebuffer, must have color image
- * @param start    the beginning point of the line
- * @param end      the ending point of the line
- * @param color    the color of the line
+ * The target framebuffer must have a valid color image.
 **/
 static void
 Fang_DrawLine(
@@ -71,11 +68,9 @@ Fang_DrawLine(
 }
 
 /**
- * @brief Draws a 1px thick outline of a rectangle in the framebuffer.
+ * Draws a 1px thick outline of a rectangle in the framebuffer.
  *
- * @param framebuf the target framebuffer, must have color image
- * @param rect     the rectangle to draw
- * @param color    the color of the rectangle
+ * The target framebuffer must have a valid color image.
 **/
 static void
 Fang_DrawRect(
@@ -108,11 +103,10 @@ Fang_DrawRect(
     }
 }
 
-/** @brief Draws a solid rectangle in the framebuffer.
+/**
+ * Draws a solid rectangle in the framebuffer.
  *
- * @param framebuf the target framebuffer, must have color image
- * @param rect     the rectangle to draw
- * @param color    the color of the rectangle
+ * The target framebuffer must have a valid color image.
 **/
 static void
 Fang_FillRect(

--- a/Source/Platform/Fang_SDL.c
+++ b/Source/Platform/Fang_SDL.c
@@ -255,7 +255,7 @@ int Fang_Main(int argc, char** argv)
 
                     if (button)
                     {
-                        button->transitions = event.button.clicks;
+                        button->transitions++;
                         button->pressed = (event.button.state == SDL_PRESSED);
                     }
 


### PR DESCRIPTION
Resolves #6 

## Description

Adds a super basic immediate mode user interface using `active`, `hot`, and `next` properties.

Also fixes an issue where the `clicks` count was being used for the mouse button transition count. 
This is incorrect because SDL only counts one `click(s)` on mouse down but zero on mouse up, meaning
we couldn't release interface buttons without clicking a second time.

## Changes
- Remove `@brief` from documentation comments
- Add extra color `FANG_GREY`
- Rename `Fang_InputWasPressed()` to `Fang_InputPressed()` and fix its logic
- Add `Fang_InputReleased()`
- Add interface struct, interface button function, and interface slider function
- Add `Fang_RectContains()`
- Fix incorrect mouse transition count assignment
