### PR TITLE
Add Text & Theming To Interface

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -39,7 +39,17 @@
 #include "Fang_Render.c"
 #include "Fang_Interface.c"
 
-Fang_Interface interface;
+Fang_Interface interface = (Fang_Interface){
+    .theme = (Fang_InterfaceTheme){
+        .font = FANG_FONT_FORMULA,
+        .colors = (Fang_InterfaceColors){
+            .background = FANG_TRANSPARENT,
+            .foreground = FANG_RED,
+            .highlight  = FANG_WHITE,
+            .disabled   = FANG_GREY,
+        },
+    },
+};
 
 static inline void
 Fang_UpdateAndRender(
@@ -59,6 +69,7 @@ Fang_UpdateAndRender(
         framebuf,
         "FANG",
         FANG_FONT_FORMULA,
+        FANG_FONTAREA_HEIGHT,
         &(Fang_Point){
             .x = (FANG_WINDOW_SIZE / 2) - (FANG_FONTAREA_WIDTH * 2),
             .y = (FANG_WINDOW_SIZE / 2) - (FANG_FONTAREA_HEIGHT * 2),

--- a/Source/Fang/Fang_Color.c
+++ b/Source/Fang/Fang_Color.c
@@ -17,15 +17,16 @@ typedef struct Fang_Color {
     uint8_t r, g, b, a;
 } Fang_Color;
 
-const Fang_Color FANG_RED    = {255,   0,   0, 255};
-const Fang_Color FANG_ORANGE = {255, 128,   0, 255};
-const Fang_Color FANG_YELLOW = {255, 255,   0, 255};
-const Fang_Color FANG_GREEN  = {  0, 255,   0, 255};
-const Fang_Color FANG_BLUE   = {  0,   0, 255, 255};
-const Fang_Color FANG_PURPLE = {128,   0, 255, 255};
-const Fang_Color FANG_WHITE  = {255, 255, 255, 255};
-const Fang_Color FANG_GREY   = {128, 128, 128, 255};
-const Fang_Color FANG_BLACK  = {  0,   0,   0, 255};
+#define FANG_RED          (Fang_Color){255,   0,   0, 255}
+#define FANG_ORANGE       (Fang_Color){255, 128,   0, 255}
+#define FANG_YELLOW       (Fang_Color){255, 255,   0, 255}
+#define FANG_GREEN        (Fang_Color){  0, 255,   0, 255}
+#define FANG_BLUE         (Fang_Color){  0,   0, 255, 255}
+#define FANG_PURPLE       (Fang_Color){128,   0, 255, 255}
+#define FANG_WHITE        (Fang_Color){255, 255, 255, 255}
+#define FANG_GREY         (Fang_Color){128, 128, 128, 255}
+#define FANG_BLACK        (Fang_Color){  0,   0,   0, 255}
+#define FANG_TRANSPARENT  (Fang_Color){  0,   0,   0,   0}
 
 /**
  * Maps RGBA components of a Fang_Color to a 32-bit, unsigned integer.

--- a/Source/Fang/Fang_Rect.c
+++ b/Source/Fang/Fang_Rect.c
@@ -59,3 +59,20 @@ Fang_RectContains(
      && point->y <= rect->y + rect->h
     );
 }
+
+/**
+ * Grows or shrinks a rectangle in each dimension by a given pixel amount.
+**/
+static inline Fang_Rect
+Fang_RectResize(
+    const Fang_Rect * const rect,
+    const int               x,
+    const int               y)
+{
+    return (Fang_Rect){
+        .x = rect->x - (x / 2),
+        .y = rect->y - (y / 2),
+        .w = rect->w + x,
+        .h = rect->h + y,
+    };
+}

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -237,6 +237,7 @@ Fang_DrawText(
           Fang_Framebuffer * const framebuf,
     const char             *       text,
     const Fang_FontType            type,
+    const int                      fontheight,
     const Fang_Point       * const origin)
 {
     assert(framebuf);
@@ -244,12 +245,14 @@ Fang_DrawText(
 
     Fang_Point position = (origin) ? *origin : (Fang_Point){0, 0};
 
+    const float ratio = (float)fontheight / (float)FANG_FONTAREA_HEIGHT;
+
     while (*text)
     {
         if (*text == ' ')
         {
             text++;
-            position.x += FANG_FONTAREA_WIDTH;
+            position.x += (int)((FANG_FONTAREA_WIDTH + 1) * ratio);
             continue;
         }
 
@@ -262,12 +265,12 @@ Fang_DrawText(
             &(Fang_Rect){
                 .x = position.x,
                 .y = position.y,
-                .w = character.w,
-                .h = character.h,
+                .w = (int)(character.w * ratio),
+                .h = (int)(character.h * ratio),
             }
         );
 
         text++;
-        position.x += FANG_FONTAREA_WIDTH;
+        position.x += (int)((FANG_FONTAREA_WIDTH + 1) * ratio);
     }
 }


### PR DESCRIPTION
Resolves #13 

## Description

This adds in basic text support for the interface slider and button.

Also creates "theme" / prop related structures for the interface so that we can set colors, fonts, etc. once 
and not have to pass them to every interface function when the values are unlikely to change.

## Changes
- Add text to interface elements
- Update `Fang_DrawText()` to support scaling
- Add `FANG_TRANSPARENT` color constant
- Change color constants to preproc defines so that they can be used in static variable initialization
- Remove unnecessary & incorrect `Fang_InterfaceReset()`
- Add `Fang_RectResize()` to make reducing/expanding rectangles a bit easier

