### PR TITLE
Add Raycasting & Map Rendering

### DIFF
--- a/Scripts/macOS/Compile.sh
+++ b/Scripts/macOS/Compile.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env sh
 
-# Copyright (C) 2021 Antonio Lassandro
+# Copyright (C) 2021  Antonio Lassandro
 
 # This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
 
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-# License for more details.
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -e
 

--- a/Source/Fang/Fang_Camera.c
+++ b/Source/Fang/Fang_Camera.c
@@ -1,0 +1,73 @@
+// Copyright (C) 2021  Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+typedef struct Fang_Camera {
+    Fang_Vec3 pos;
+    Fang_Vec3 dir;
+    Fang_Vec3 cam;
+} Fang_Camera;
+
+static inline void
+Fang_CameraRotate(
+          Fang_Camera * const camera,
+    const float               angle,
+    const float               pitch)
+{
+    assert(camera);
+
+    const Fang_Vec2 rotation = {
+        .x = cosf(angle),
+        .y = sinf(angle),
+    };
+
+    Fang_Vec3 * const dir = &camera->dir;
+    Fang_Vec3 * const cam = &camera->cam;
+
+    dir->x = dir->x * rotation.x - dir->y * rotation.y;
+    dir->y = dir->x * rotation.y + dir->y * rotation.x;
+    cam->x = cam->x * rotation.x - cam->y * rotation.y;
+    cam->y = cam->x * rotation.y + cam->y * rotation.x;
+    cam->z = clamp(cam->z + pitch, -1.0f, 1.0f);
+}
+
+static inline Fang_Rect
+Fang_CameraProjectSurface(
+    const Fang_Camera * const camera,
+    const Fang_Rect   * const surface,
+    const float               dist,
+    const Fang_Rect   * const viewport)
+{
+    assert(camera);
+    assert(surface);
+    assert(viewport);
+
+    const float ratio  = viewport->h / dist;
+    const float height = (surface->y / (float)FANG_TILE_SIZE) * ratio;
+    const float size   = (surface->h / (float)FANG_TILE_SIZE) * ratio - ratio;
+
+    return (Fang_Rect){
+        .x = surface->x,
+        .y = (int)(
+            (viewport->h / 2)
+          - (ratio / 2.0f)
+          - height
+          - size
+          + (camera->cam.z * viewport->h)
+          + (camera->pos.z / dist)
+        ),
+        .w = surface->w,
+        .h = (int)(ratio + size),
+    };
+}

--- a/Source/Fang/Fang_Color.c
+++ b/Source/Fang/Fang_Color.c
@@ -1,17 +1,17 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 typedef struct Fang_Color {
     uint8_t r, g, b, a;

--- a/Source/Fang/Fang_Font.c
+++ b/Source/Fang/Fang_Font.c
@@ -1,17 +1,17 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * All fonts should be 8x9 in size, with a 1px barrier in between each

--- a/Source/Fang/Fang_Framebuffer.c
+++ b/Source/Fang/Fang_Framebuffer.c
@@ -1,17 +1,17 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * A structure used for rendering to the screen.

--- a/Source/Fang/Fang_Image.c
+++ b/Source/Fang/Fang_Image.c
@@ -1,17 +1,17 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * A container for image pixel data.

--- a/Source/Fang/Fang_Input.c
+++ b/Source/Fang/Fang_Input.c
@@ -1,17 +1,17 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * A simple input button.

--- a/Source/Fang/Fang_Interface.c
+++ b/Source/Fang/Fang_Interface.c
@@ -1,17 +1,17 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * A structure to hold colors used in interface components.

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -1,0 +1,212 @@
+// Copyright (C) 2021  Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+static inline Fang_TileType
+Fang_MapQueryType(
+    int x,
+    int y)
+{
+    static const Fang_TileType map[8][8] = {
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        {1, 0, 0, 0, 0, 0, 2, 1},
+        {1, 0, 0, 0, 0, 0, 0, 1},
+        {1, 0, 0, 0, 0, 0, 0, 1},
+        {1, 0, 0, 0, 0, 0, 0, 1},
+        {1, 0, 0, 0, 0, 2, 0, 1},
+        {1, 1, 0, 0, 0, 0, 0, 1},
+        {1, 1, 1, 1, 1, 1, 1, 1},
+    };
+
+    x /= FANG_TILE_SIZE;
+    y /= FANG_TILE_SIZE;
+
+    if (x < 0 || x >= 8)
+        return FANG_TILETYPE_NONE;
+
+    if (y < 0 || y >= 8)
+        return FANG_TILETYPE_NONE;
+
+    return map[y][x];
+}
+
+static inline Fang_TileSize
+Fang_MapQuerySize(
+    const int x,
+    const int y)
+{
+    const Fang_TileType type = Fang_MapQueryType(x, y);
+
+    switch (type)
+    {
+        case FANG_TILETYPE_SOLID:
+            return (Fang_TileSize){0, FANG_TILE_SIZE};
+
+        case FANG_TILETYPE_FLOATING:
+            return (Fang_TileSize){FANG_TILE_SIZE * 2, FANG_TILE_SIZE};
+
+        default:
+            return (Fang_TileSize){0, 0};
+    }
+}
+
+static inline Fang_Color
+Fang_MapQueryColor(
+    const int x,
+    const int y)
+{
+    const Fang_TileType type = Fang_MapQueryType(x, y);
+
+    switch (type)
+    {
+        case FANG_TILETYPE_SOLID:
+            return FANG_WHITE;
+
+        case FANG_TILETYPE_FLOATING:
+            return FANG_GREY;
+
+        default:
+            return FANG_TRANSPARENT;
+    }
+}
+
+static void
+Fang_MapRenderWalls(
+          Fang_Framebuffer * const framebuf,
+    const Fang_Camera      * const camera,
+    const Fang_Ray         * const rays,
+    const size_t                   count)
+{
+    assert(framebuf);
+    assert(camera);
+    assert(rays);
+    assert(count);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        const Fang_Ray * const ray = &rays[i];
+
+        for (size_t j = ray->hit_count; j-- > 0;)
+        {
+            const Fang_RayHit * const hit = &ray->hits[j];
+
+            if (hit->front_dist <= 0.0f)
+                continue;
+
+            if (!Fang_MapQueryType(hit->tile_pos.x, hit->tile_pos.y))
+                continue;
+
+            const Fang_TileSize wall_size = Fang_MapQuerySize(
+                hit->tile_pos.x, hit->tile_pos.y
+            );
+
+            Fang_Rect front_face;
+            Fang_Rect  back_face;
+
+            /* Calculate and draw front and back faces of tile */
+            for (size_t k = 0; k < 2; ++k)
+            {
+                const float face_dist = (k == 0)
+                    ? hit->front_dist
+                    : hit->back_dist;
+
+                const Fang_Rect surface = Fang_CameraProjectSurface(
+                    camera,
+                    &(Fang_Rect){
+                        .x = (int)i,
+                        .y = wall_size.height,
+                        .w = 1,
+                        .h = wall_size.size,
+                    },
+                    face_dist,
+                    &(Fang_Rect){0, 0, FANG_WINDOW_SIZE, FANG_WINDOW_SIZE}
+                );
+
+                if (k == 0)
+                    front_face = surface;
+                else
+                    back_face = surface;
+
+                /* NOTE: Cull backfaces until transparent texture support */
+                if (k == 1)
+                    continue;
+
+                const Fang_Color color = Fang_MapQueryColor(
+                    hit->tile_pos.x, hit->tile_pos.y
+                );
+
+                Fang_FillRect(framebuf, &surface, &color);
+            }
+
+            /* Draw top or bottom of tile based on front/back faces */
+            {
+                Fang_Rect face = {.x = 0};
+
+                /* Draw top */
+                if (wall_size.height + wall_size.size < camera->pos.z)
+                {
+                    const int face_diff = front_face.y - back_face.y;
+
+                    face = (Fang_Rect){
+                        .x = (int)i,
+                        .y = back_face.y,
+                        .w = 1,
+                        .h = face_diff,
+                    };
+                }
+                /* Draw bottom */
+                else if (wall_size.height > camera->pos.z)
+                {
+                    const int face_diff = ( back_face.y +  back_face.h)
+                                        - (front_face.y + front_face.h);
+
+                    face = (Fang_Rect){
+                        .x = (int)i,
+                        .y = front_face.y + front_face.h,
+                        .w = 1,
+                        .h = face_diff,
+                    };
+                }
+
+                if (face.h)
+                {
+                    Fang_Color color = Fang_MapQueryColor(
+                        hit->tile_pos.x, hit->tile_pos.y
+                    );
+
+                    color.r /= 2;
+                    color.g /= 2;
+                    color.b /= 2;
+
+                    Fang_FillRect(framebuf, &face, &color);
+                }
+            }
+        }
+    }
+}
+
+static void
+Fang_MapRender(
+          Fang_Framebuffer * const framebuf,
+    const Fang_Camera      * const camera,
+    const Fang_Ray         * const rays,
+    const size_t                   count)
+{
+    assert(framebuf);
+    assert(camera);
+    assert(rays);
+    assert(count);
+
+    Fang_MapRenderWalls(framebuf, camera, rays, count);
+}

--- a/Source/Fang/Fang_Ray.c
+++ b/Source/Fang/Fang_Ray.c
@@ -1,0 +1,265 @@
+// Copyright (C) 2021  Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+static inline Fang_TileType Fang_MapQueryType(int, int);
+
+enum {
+    FANG_RAY_MAX_STEPS = 64,
+};
+
+typedef enum Fang_Direction {
+    FANG_DIRECTION_NORTH,
+    FANG_DIRECTION_SOUTH,
+    FANG_DIRECTION_EAST,
+    FANG_DIRECTION_WEST,
+} Fang_Direction;
+
+typedef struct Fang_RayHit {
+    Fang_Vec2      front_hit;
+    float          front_dist;
+    Fang_Vec2      back_hit;
+    float          back_dist;
+    Fang_Point     tile_pos;
+    Fang_Direction norm_dir;
+} Fang_RayHit;
+
+typedef struct Fang_Ray {
+    Fang_RayHit hits[FANG_RAY_MAX_STEPS];
+    size_t      hit_count;
+} Fang_Ray;
+
+static inline void
+Fang_RayCast(
+    const Fang_Camera * const camera,
+          Fang_Ray    * const rays,
+    const size_t              count)
+{
+    assert(camera);
+    assert(rays);
+    assert(count);
+
+    const Fang_Vec3 * const dir = &camera->dir;
+    const Fang_Vec3 * const cam = &camera->cam;
+
+    const Fang_Vec2 norm_pos = {
+        .x = camera->pos.x / FANG_TILE_SIZE,
+        .y = camera->pos.y / FANG_TILE_SIZE,
+    };
+
+    memset(rays, 0, sizeof(Fang_Ray) * count);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        /* X coordinate in camera space, normalized -1.0f..1.0f */
+        const float ray_cam = 2.0f * (1.0f - (float)i / (float)count) - 1.0f;
+
+        /* Map ray start position onto camera plane */
+        const Fang_Vec2 cam_ray = {
+            .x = dir->x + cam->x * ray_cam,
+            .y = dir->y + cam->y * ray_cam,
+        };
+
+        const Fang_Vec2 delta_dist = {
+            .x = (cam_ray.y == 0.0f)
+                ? 0.0f
+                : cam_ray.x == 0.0f ? 0.0f : fabsf(1.0f / cam_ray.x),
+            .y = (cam_ray.x == 0.0f)
+                ? 0.0f
+                : (cam_ray.y == 0.0f) ? 0.0f : fabsf(1.0f / cam_ray.y),
+        };
+
+        Fang_Vec2 floor_norm = {
+            .x = floorf(norm_pos.x),
+            .y = floorf(norm_pos.y),
+        };
+
+        Fang_Vec2 step_dist;
+        Fang_Vec2 side_dist;
+        Fang_Direction side_dir_x;
+        Fang_Direction side_dir_y;
+
+        if (cam_ray.x < 0.0f)
+        {
+            step_dist.x = -1.0f;
+            side_dist.x = (norm_pos.x - floor_norm.x) * delta_dist.x;
+            side_dir_x  = FANG_DIRECTION_EAST;
+        }
+        else
+        {
+            step_dist.x = 1.0f;
+            side_dist.x = (floor_norm.x + 1.0f - norm_pos.x) * delta_dist.x;
+            side_dir_x  = FANG_DIRECTION_WEST;
+        }
+
+        if (cam_ray.y < 0.0f)
+        {
+            step_dist.y = -1.0f;
+            side_dist.y = (norm_pos.y - floor_norm.y) * delta_dist.y;
+            side_dir_y  = FANG_DIRECTION_SOUTH;
+        }
+        else
+        {
+            step_dist.y = 1.0f;
+            side_dist.y = (floor_norm.y + 1.0f - norm_pos.y) * delta_dist.y;
+            side_dir_y  = FANG_DIRECTION_NORTH;
+        }
+
+        size_t hit_count = 0;
+
+        for (size_t step = 0; step < FANG_RAY_MAX_STEPS; ++step)
+        {
+            Fang_RayHit * const hit = &rays[i].hits[hit_count];
+
+            if (side_dist.x < side_dist.y)
+            {
+                floor_norm.x += step_dist.x;
+                side_dist.x  += delta_dist.x;
+                hit->norm_dir = side_dir_x;
+            }
+            else if (side_dist.x > side_dist.y)
+            {
+                floor_norm.y += step_dist.y;
+                side_dist.y  += delta_dist.y;
+                hit->norm_dir = side_dir_y;
+            }
+            else /* 0 case */
+            {
+                if (step_dist.x < step_dist.y)
+                {
+                    floor_norm.x += step_dist.x;
+                    side_dist.x  += delta_dist.x;
+                    hit->norm_dir = side_dir_x;
+                }
+                else
+                {
+                    floor_norm.y += step_dist.y;
+                    side_dist.y  += delta_dist.y;
+                    hit->norm_dir = side_dir_y;
+                }
+            }
+
+            const Fang_Point tile_pos = {
+                .x = (int)(floor_norm.x * FANG_TILE_SIZE),
+                .y = (int)(floor_norm.y * FANG_TILE_SIZE),
+            };
+
+            const Fang_TileType wall_type = Fang_MapQueryType(
+                tile_pos.x, tile_pos.y
+            );
+
+            if (wall_type)
+            {
+                /* Check the axis of collision */
+                if (hit->norm_dir == side_dir_x)
+                {
+                    hit->front_dist = (
+                        floor_norm.x - norm_pos.x + (1.0f - step_dist.x) / 2.0f
+                    );
+
+                    if (cam_ray.x != 0.0f)
+                        hit->front_dist /= cam_ray.x;
+                }
+                else if (hit->norm_dir == side_dir_y)
+                {
+                    hit->front_dist = (
+                        floor_norm.y - norm_pos.y + (1.0f - step_dist.y) / 2.0f
+                    );
+
+                    if (cam_ray.y != 0.0f)
+                        hit->front_dist /= cam_ray.y;
+                }
+
+                hit->tile_pos = tile_pos;
+
+                hit->front_hit = (Fang_Vec2){
+                    .x = camera->pos.x + (hit->front_dist * cam_ray.x)
+                       * FANG_TILE_SIZE,
+                    .y = camera->pos.y + (hit->front_dist * cam_ray.y)
+                       * FANG_TILE_SIZE,
+                };
+
+                const Fang_Vec2 old_floor_norm = floor_norm;
+                const Fang_Vec2 old_side_dist  = side_dist;
+
+                /* Run an additional increment to calculate the back face hit */
+                {
+                    Fang_Direction dir = hit->norm_dir;
+
+                    if (side_dist.x < side_dist.y)
+                    {
+                        floor_norm.x += step_dist.x;
+                        side_dist.x  += delta_dist.x;
+                        dir = side_dir_x;
+                    }
+                    else if (side_dist.x > side_dist.y)
+                    {
+                        floor_norm.y += step_dist.y;
+                        side_dist.y  += delta_dist.y;
+                        dir = side_dir_y;
+                    }
+                    else /* 0 case */
+                    {
+                        if (step_dist.x < step_dist.y)
+                        {
+                            floor_norm.x += step_dist.x;
+                            side_dist.x  += delta_dist.x;
+                            dir = side_dir_x;
+                        }
+                        else
+                        {
+                            floor_norm.y += step_dist.y;
+                            side_dist.y  += delta_dist.y;
+                            dir = side_dir_y;
+                        }
+                    }
+
+                    /* Check the axis of collision */
+                    if (dir == side_dir_x)
+                    {
+                        hit->back_dist = (
+                            floor_norm.x - norm_pos.x + (1.0f - step_dist.x) / 2.0f
+                        );
+
+                        if (cam_ray.x != 0.0f)
+                            hit->back_dist /= cam_ray.x;
+                    }
+                    else if (dir == side_dir_y)
+                    {
+                        hit->back_dist = (
+                            floor_norm.y - norm_pos.y + (1.0f - step_dist.y) / 2.0f
+                        );
+
+                        if (cam_ray.y != 0.0f)
+                            hit->back_dist /= cam_ray.y;
+                    }
+
+                    hit->back_hit = (Fang_Vec2){
+                        .x = camera->pos.x + (hit->back_dist * cam_ray.x)
+                           * FANG_TILE_SIZE,
+                        .y = camera->pos.y + (hit->back_dist * cam_ray.y)
+                           * FANG_TILE_SIZE,
+                    };
+                }
+
+                floor_norm = old_floor_norm;
+                side_dist  = old_side_dist;
+
+                hit_count++;
+            }
+        }
+
+        rays[i].hit_count = hit_count;
+    }
+}

--- a/Source/Fang/Fang_Rect.c
+++ b/Source/Fang/Fang_Rect.c
@@ -1,17 +1,17 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 typedef struct Fang_Point {
     int x, y;

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -1,17 +1,17 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * Draws a line in the framebuffer using Bresenham's Algorithm.

--- a/Source/Fang/Fang_TGA.c
+++ b/Source/Fang/Fang_TGA.c
@@ -1,17 +1,17 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * Parses and loads a TGA file from memory.

--- a/Source/Fang/Fang_Tile.c
+++ b/Source/Fang/Fang_Tile.c
@@ -13,10 +13,15 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * A container for arbitrary data with a length (in bytes).
-**/
-typedef struct Fang_Buffer {
-    void   * data;
-    size_t   size;
-} Fang_Buffer;
+typedef enum Fang_TileType {
+    FANG_TILETYPE_NONE,
+    FANG_TILETYPE_SOLID,
+    FANG_TILETYPE_FLOATING,
+
+    FANG_NUM_TILETYPE,
+} Fang_TileType;
+
+typedef struct Fang_TileSize {
+    int height;
+    int size;
+} Fang_TileSize;

--- a/Source/Fang/Fang_Vector.c
+++ b/Source/Fang/Fang_Vector.c
@@ -13,10 +13,10 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * A container for arbitrary data with a length (in bytes).
-**/
-typedef struct Fang_Buffer {
-    void   * data;
-    size_t   size;
-} Fang_Buffer;
+typedef struct Fang_Vec2 {
+    float x, y;
+} Fang_Vec2;
+
+typedef struct Fang_Vec3 {
+    float x, y, z;
+} Fang_Vec3;

--- a/Source/Main.c
+++ b/Source/Main.c
@@ -1,19 +1,22 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-const int FANG_WINDOW_SIZE = 512;
+enum {
+  FANG_WINDOW_SIZE = 512,
+  FANG_TILE_SIZE   = 32,
+};
 
 #include "Platform/Fang_SDL.c"
 

--- a/Source/Platform/Fang_SDL.c
+++ b/Source/Platform/Fang_SDL.c
@@ -1,17 +1,17 @@
-// Copyright (C) 2021 Antonio Lassandro
+// Copyright (C) 2021  Antonio Lassandro
 
 // This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
 
 // This program is distributed in the hope that it will be useful, but WITHOUT
 // ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
-// License for more details.
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "../Fang/Fang.c"
 #include <SDL2/SDL.h>
@@ -427,6 +427,7 @@ int Fang_Main(int argc, char** argv)
             framebuf.color.width  = FANG_WINDOW_SIZE;
             framebuf.color.height = FANG_WINDOW_SIZE;
             framebuf.color.stride = SDL_BYTESPERPIXEL(SDL_PIXELFORMAT_RGBA8888);
+            framebuf.enable_stencil = false;
 
             const int error = SDL_LockTexture(
                 texture,


### PR DESCRIPTION
Resolves #15 

## Description

Implements a temporary 8x8 map, with hard-coded tile types, colors, and sizes.

A camera is placed in the scene and slowly rotates, showing the surrounding tiles. The
map also supports varying sizes and y-offsets for tiles.

## Changes
- Adds vector, camera, map, and ray structs and functions
- Adds a camera to the scene and raycast-renders the temporary map while rotating the view
- Add `breakpoint()` and `clamp()` macros
- Fixes file license headers using the Affero GPL text instead of GPLv3
