### PR TITLE
Add Framebuffer Transform & Minimap

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -41,6 +41,7 @@
 #include "Fang_Color.c"
 #include "Fang_Rect.c"
 #include "Fang_Vector.c"
+#include "Fang_Matrix.c"
 #include "Fang_Input.c"
 #include "Fang_Image.c"
 #include "Fang_TGA.c"
@@ -70,7 +71,7 @@ Fang_Ray raycast[FANG_WINDOW_SIZE];
 Fang_Camera camera = (Fang_Camera){
     .pos = {
         .x = FANG_TILE_SIZE * 2,
-        .y = FANG_TILE_SIZE * 3,
+        .y = FANG_TILE_SIZE * 2,
         .z = FANG_TILE_SIZE / 2,
     },
     .dir = {.x = -1.0f},
@@ -93,7 +94,7 @@ Fang_UpdateAndRender(
 
     Fang_CameraRotate(
         &camera,
-        0.005f,
+        0.025f,
         0
     );
 
@@ -108,6 +109,19 @@ Fang_UpdateAndRender(
         &camera,
         raycast,
         (size_t)FANG_WINDOW_SIZE
+    );
+
+    Fang_MinimapRender(
+        framebuf,
+        &camera,
+        raycast,
+        (size_t)FANG_WINDOW_SIZE,
+        &(Fang_Rect){
+            .x = FANG_WINDOW_SIZE - 64,
+            .y = FANG_WINDOW_SIZE - 64,
+            .w = 64,
+            .h = 64,
+        }
     );
 
     Fang_DrawText(

--- a/Source/Fang/Fang_Matrix.c
+++ b/Source/Fang/Fang_Matrix.c
@@ -1,0 +1,104 @@
+// Copyright (C) 2021  Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+typedef struct Fang_Mat3x3 {
+    float m00, m01, m02,
+          m10, m11, m12,
+          m20, m21, m22;
+} Fang_Mat3x3;
+
+#define Fang_MatMult(a, b) _Generic((b), \
+        Fang_Vec3:   Fang_Mat3x3Multv, \
+        Fang_Point:  Fang_Mat3x3Multp, \
+        Fang_Mat3x3: Fang_Mat3x3Mult   \
+    )(a, b)
+
+static inline Fang_Mat3x3
+Fang_Mat3x3Identity(void)
+{
+    return (Fang_Mat3x3){
+        1.0f, 0.0f, 0.0f,
+        0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 1.0f,
+    };
+}
+
+static inline Fang_Mat3x3
+Fang_Mat3x3Mult(
+    const Fang_Mat3x3 a,
+    const Fang_Mat3x3 b)
+{
+    return (Fang_Mat3x3){
+        a.m00 * b.m00 + a.m01 * b.m10 + a.m02 * b.m20,
+        a.m00 * b.m01 + a.m01 * b.m11 + a.m02 * b.m21,
+        a.m00 * b.m02 + a.m01 * b.m12 + a.m02 * b.m22,
+
+        a.m10 * b.m00 + a.m11 * b.m10 + a.m12 * b.m20,
+        a.m10 * b.m01 + a.m11 * b.m11 + a.m12 * b.m21,
+        a.m10 * b.m02 + a.m11 * b.m12 + a.m12 * b.m22,
+
+        a.m20 * b.m00 + a.m21 * b.m10 + a.m22 * b.m20,
+        a.m20 * b.m01 + a.m21 * b.m11 + a.m22 * b.m21,
+        a.m20 * b.m02 + a.m21 * b.m12 + a.m22 * b.m22,
+    };
+}
+
+static inline Fang_Vec3
+Fang_Mat3x3Multv(
+    const Fang_Mat3x3 a,
+    const Fang_Vec3   b)
+{
+    return (Fang_Vec3){
+        a.m00 * b.x + a.m01 * b.y + a.m02 * b.z,
+        a.m10 * b.x + a.m11 * b.y + a.m12 * b.z,
+        a.m20 * b.x + a.m21 * b.y + a.m22 * b.z,
+    };
+}
+
+static inline Fang_Point
+Fang_Mat3x3Multp(
+    const Fang_Mat3x3 a,
+    const Fang_Point  b)
+{
+    const Fang_Vec3 result = Fang_Mat3x3Multv(
+        a, (Fang_Vec3){.x = b.x, .y = b.y, .z = 1.0f}
+    );
+
+    return (Fang_Point){.x = (int)result.x, .y = (int)result.y};
+}
+
+static inline Fang_Mat3x3
+Fang_Mat3x3Translate(
+    const float x,
+    const float y)
+{
+    return (Fang_Mat3x3){
+        1.0f, 0.0f,    x,
+        0.0f, 1.0f,    y,
+        0.0f, 0.0f, 1.0f,
+    };
+}
+
+static inline Fang_Mat3x3
+Fang_Mat3x3Scale(
+    const float x,
+    const float y)
+{
+    return (Fang_Mat3x3){
+           x, 0.0f, 0.0f,
+        0.0f,    y, 0.0f,
+        0.0f, 0.0f, 1.0f,
+    };
+}

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -68,6 +68,38 @@ Fang_DrawLine(
 }
 
 /**
+ * Draws a vertical line across the framebuffer.
+**/
+static inline void
+Fang_DrawVerticalLine(
+          Fang_Framebuffer * const framebuf,
+    const int                      x,
+    const Fang_Color       * const color)
+{
+    assert(framebuf);
+    assert(color);
+
+    for (int y = 0; y < framebuf->color.height; ++y)
+        Fang_FramebufferPutPixel(framebuf, &(Fang_Point){x, y}, color);
+}
+
+/**
+ * Draws a horizontal line across the framebuffer.
+**/
+static inline void
+Fang_DrawHorizontalLine(
+          Fang_Framebuffer * const framebuf,
+    const int                      y,
+    const Fang_Color       * const color)
+{
+    assert(framebuf);
+    assert(color);
+
+    for (int x = 0; x < framebuf->color.width; ++x)
+        Fang_FramebufferPutPixel(framebuf, &(Fang_Point){x, y}, color);
+}
+
+/**
  * Draws a 1px thick outline of a rectangle in the framebuffer.
  *
  * The target framebuffer must have a valid color image.

--- a/Source/Platform/Fang_SDL.c
+++ b/Source/Platform/Fang_SDL.c
@@ -428,6 +428,7 @@ int Fang_Main(int argc, char** argv)
             framebuf.color.height = FANG_WINDOW_SIZE;
             framebuf.color.stride = SDL_BYTESPERPIXEL(SDL_PIXELFORMAT_RGBA8888);
             framebuf.enable_stencil = false;
+            framebuf.transform = Fang_Mat3x3Identity();
 
             const int error = SDL_LockTexture(
                 texture,


### PR DESCRIPTION
Resolves #23 

## Description

Allows for performing affine transformations while drawing into a framebuffer. 

## Changes
- Adds 3x3 matrix struct and functions
- Applies matrix transformation when calling `Fang_FramebufferPutPixel()`
- Adds options for getting/setting the framebuffer's viewport
- Adds a minimap in the bottom-right corner for debugging purposes
- Add helper functions for drawing vertical/horizontal lines across framebuffers

