### PR TITLE
Move Image Pixel Access To Function

### DIFF
--- a/Source/Fang/Fang_Framebuffer.c
+++ b/Source/Fang/Fang_Framebuffer.c
@@ -145,6 +145,11 @@ Fang_FramebufferClear(
         Fang_ImageClear(&framebuf->stencil);
 }
 
+/**
+ * Get the rectangle representing the framebuffer's viewport (0, 0, w, h).
+ *
+ * This does not take the framebuffer's transform into account.
+**/
 static inline Fang_Rect
 Fang_FramebufferGetViewport(
     Fang_Framebuffer * const framebuf)
@@ -159,6 +164,12 @@ Fang_FramebufferGetViewport(
     };
 }
 
+/**
+ * Sets the bounds with which the viewport should draw into.
+ *
+ * Because this is a viewport transform and not a clip region, the framebuffer
+ * will still attempt to draw all contents within the new area.
+**/
 static inline void
 Fang_FramebufferSetViewport(
           Fang_Framebuffer * const framebuf,

--- a/Source/Fang/Fang_Image.c
+++ b/Source/Fang/Fang_Image.c
@@ -45,3 +45,43 @@ Fang_ImageClear(
         (size_t)(image->pitch * image->height)
     );
 }
+
+/**
+ * Query an image for a 32-bit color value.
+ *
+ * If the image depth is less than 32 bits, the missing channels are defaulted
+ * to 255.
+**/
+static inline Fang_Color
+Fang_ImageQuery(
+    const Fang_Image * const image,
+    const Fang_Point * const point)
+{
+    assert(image);
+    assert(image->pixels);
+    assert(point);
+    assert(point->x >= 0 && point->x < image->width);
+    assert(point->y >= 0 && point->y < image->height);
+
+    uint32_t pixel = 0;
+
+    for (int p = 0; p < image->stride; ++p)
+    {
+        pixel |= *(
+            image->pixels + p
+          + (point->x * image->stride)
+          + (point->y * image->pitch)
+        );
+
+        if (p < image->stride - 1)
+            pixel <<= 8;
+    }
+
+    for (int p = image->stride; p < 4; ++p)
+    {
+        pixel <<= 8;
+        pixel |= 0x000000FF;
+    }
+
+    return Fang_ColorFromRGBA(pixel);
+}


### PR DESCRIPTION
## Description

Although it wasn't resulting in a crash, the pixel access logic of the tile rendering was going out of bounds.

Instead of writing the same code everywhere this piece was able to be moved into its own function, which also
allows for easily adding some extra assertions on a per-pixel basis.

## Changes
- Adds `Fang_ImageQuery()` image pixel access function
- Update function documentations
- Fix over-by-one memory access typos in tile rendering code

