### PR TITLE
Implement Map Fog

### DIFF
--- a/Source/Fang/Fang_Color.c
+++ b/Source/Fang/Fang_Color.c
@@ -59,3 +59,42 @@ Fang_ColorFromRGBA(
     result.r = color & 0x000000FF;
     return result;
 }
+
+/**
+ * Performs alpha blending on two colors.
+**/
+static inline Fang_Color
+Fang_ColorBlend(
+    const Fang_Color * const src,
+    const Fang_Color * const dst)
+{
+    assert(src);
+    assert(dst);
+
+    const float src_r = src->r / 255.0f,
+                src_g = src->g / 255.0f,
+                src_b = src->b / 255.0f,
+                src_a = src->a / 255.0f;
+
+    float dst_r = dst->r / 255.0f,
+          dst_g = dst->g / 255.0f,
+          dst_b = dst->b / 255.0f,
+          dst_a = dst->a / 255.0f;
+
+    dst_r = (src_r * src_a) + (dst_r * (1.0f - src_a));
+    dst_g = (src_g * src_a) + (dst_g * (1.0f - src_a));
+    dst_b = (src_b * src_a) + (dst_b * (1.0f - src_a));
+    dst_a = src_a + (dst_a * (1.0f - src_a));
+
+    dst_r = min(max(dst_r, 0.0f), 1.0f);
+    dst_g = min(max(dst_g, 0.0f), 1.0f);
+    dst_b = min(max(dst_b, 0.0f), 1.0f);
+    dst_a = min(max(dst_a, 0.0f), 1.0f);
+
+    return (Fang_Color){
+        .r = (uint8_t)(dst_r * 255.0f),
+        .g = (uint8_t)(dst_g * 255.0f),
+        .b = (uint8_t)(dst_b * 255.0f),
+        .a = (uint8_t)(dst_a * 255.0f),
+    };
+}

--- a/Source/Fang/Fang_Framebuffer.c
+++ b/Source/Fang/Fang_Framebuffer.c
@@ -91,36 +91,9 @@ Fang_FramebufferPutPixel(
           +  trans_point.x * framebuf->color.stride)
         );
 
-        Fang_Color dst_color = Fang_ColorFromRGBA(*dst);
-
-        const float src_r = color->r / 255.0f,
-                    src_g = color->g / 255.0f,
-                    src_b = color->b / 255.0f,
-                    src_a = color->a / 255.0f;
-
-        float dst_r = dst_color.r / 255.0f,
-              dst_g = dst_color.g / 255.0f,
-              dst_b = dst_color.b / 255.0f,
-              dst_a = dst_color.a / 255.0f;
-
-        dst_r = (src_r * src_a) + (dst_r * (1.0f - src_a));
-        dst_g = (src_g * src_a) + (dst_g * (1.0f - src_a));
-        dst_b = (src_b * src_a) + (dst_b * (1.0f - src_a));
-        dst_a = src_a + (dst_a * (1.0f - src_a));
-
-        dst_r = min(max(dst_r, 0.0f), 1.0f);
-        dst_g = min(max(dst_g, 0.0f), 1.0f);
-        dst_b = min(max(dst_b, 0.0f), 1.0f);
-        dst_a = min(max(dst_a, 0.0f), 1.0f);
-
-        *dst = Fang_ColorToRGBA(
-            &(Fang_Color){
-                .r = (uint8_t)(dst_r * 255.0f),
-                .g = (uint8_t)(dst_g * 255.0f),
-                .b = (uint8_t)(dst_b * 255.0f),
-                .a = (uint8_t)(dst_a * 255.0f),
-            }
-        );
+        Fang_Color dst_color     = Fang_ColorFromRGBA(*dst);
+        Fang_Color blended_color = Fang_ColorBlend(color, &dst_color);
+        *dst = Fang_ColorToRGBA(&blended_color);
     }
 
     return write;

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -26,6 +26,9 @@ typedef struct Fang_Map {
 
     Fang_Image skybox;
     Fang_Image floor;
+
+    Fang_Color fog;
+    float      fog_distance;
 } Fang_Map;
 
 enum {
@@ -49,6 +52,8 @@ Fang_Map temp_map = {
     .width = temp_map_width,
     .height = temp_map_height,
     .tile_size = 16,
+    .fog = FANG_BLACK,
+    .fog_distance = 4,
 };
 
 static inline Fang_TileType


### PR DESCRIPTION
Resolves #19 

## Description

Adds basic fog blending when drawing the map floor and tiles.

## Changes
- Moves framebuffer alpha blending code into its own function `Fang_ColorBlend()`
- Adds `fog` and `fog_distance` to the map structure
- Adds fog blending in floor and tile rendering functions

