### PR TITLE
Add File Loading Platform Calls

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -22,23 +22,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef min
-  #define min(x, y) (x < y ? x : y)
-#endif
-
-#ifndef max
-  #define max(x, y) (x > y ? x : y)
-#endif
-
-#ifndef clamp
-  #define clamp(x, low, high) (max(min(x, high), low))
-#endif
-
-#ifndef breakpoint
-  #define breakpoint() raise(SIGTRAP)
-#endif
-
-#include "Fang_Memory.c"
+#include "Fang_Defines.c"
+#include "Fang_Macros.c"
+#include "Fang_File.c"
 #include "Fang_Color.c"
 #include "Fang_Rect.c"
 #include "Fang_Vector.c"

--- a/Source/Fang/Fang_Defines.c
+++ b/Source/Fang/Fang_Defines.c
@@ -14,9 +14,7 @@
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * A container for arbitrary data with a length (in bytes).
+ * Function declarations that should be fulfilled by the platform layer should
+ * be prepended with this definition (no-op) for clarity.
 **/
-typedef struct Fang_Buffer {
-    void   * data;
-    size_t   size;
-} Fang_Buffer;
+#define FANG_PLATFORM_CALL

--- a/Source/Fang/Fang_File.c
+++ b/Source/Fang/Fang_File.c
@@ -1,0 +1,51 @@
+// Copyright (C) 2021  Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A container for file data with a length (in bytes).
+**/
+typedef struct Fang_File {
+    void   * data;
+    size_t   size;
+} Fang_File;
+
+/**
+ * Error values representing what went wrong during the loading of a resource.
+**/
+typedef enum Fang_FileError {
+    FANG_FILE_ERROR_NONE,
+    FANG_FILE_ERROR_CANT_OPEN,
+    FANG_FILE_ERROR_UNKNOWN_SIZE,
+    FANG_FILE_ERROR_BAD_ALLOCATION,
+    FANG_FILE_ERROR_BAD_READ,
+
+    FANG_NUM_FILE_ERROR,
+} Fang_FileError;
+
+/**
+ * Loads a game file.
+ *
+ * This function is defined by the platform layer, but will typically prepend
+ * the supplied file name with the resource path (such as the app bundle, data
+ * directory, etc.) and then read the file at that location.
+**/
+FANG_PLATFORM_CALL
+Fang_FileError Fang_LoadFile(const char * /* filename */, Fang_File *);
+
+/**
+ * Frees a game file that was allocated via Fang_LoadFile().
+**/
+FANG_PLATFORM_CALL
+void Fang_FreeFile(Fang_File *);

--- a/Source/Fang/Fang_Macros.c
+++ b/Source/Fang/Fang_Macros.c
@@ -13,19 +13,18 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-enum {
-  FANG_WINDOW_SIZE = 256,
-};
+#ifndef min
+  #define min(x, y) (x < y ? x : y)
+#endif
 
-#include "Platform/FangSDL.c"
+#ifndef max
+  #define max(x, y) (x > y ? x : y)
+#endif
 
-int main(int argc, char **argv)
-{
-    // NOTE: When building with Sublime the output panel doesn't seem to update
-    //       properly without an unbuffered stdout
-    #ifdef FANG_UNBUFFERED_STDOUT
-      setbuf(stdout, NULL);
-    #endif
+#ifndef clamp
+  #define clamp(x, low, high) (max(min(x, high), low))
+#endif
 
-    return Fang_Main(argc, argv);
-}
+#ifndef breakpoint
+  #define breakpoint() raise(SIGTRAP)
+#endif

--- a/Source/Fang/Fang_TGA.c
+++ b/Source/Fang/Fang_TGA.c
@@ -25,11 +25,11 @@
 **/
 static Fang_Image
 Fang_TGALoad(
-    Fang_Buffer * const buffer)
+    Fang_File * const file)
 {
-    assert(buffer);
+    assert(file);
 
-    const uint8_t * file = buffer->data;
+    const uint8_t * data = file->data;
 
     enum {
         TGA_IMAGE_NONE    =  0, /* Empty                           */
@@ -67,18 +67,18 @@ Fang_TGALoad(
         uint8_t  image_descriptor;
     } header;
 
-    memcpy(&header.id_len,           file, sizeof( uint8_t)); file += sizeof( uint8_t);
-    memcpy(&header.map_included,     file, sizeof( uint8_t)); file += sizeof( uint8_t);
-    memcpy(&header.image_type,       file, sizeof( uint8_t)); file += sizeof( uint8_t);
-    memcpy(&header.map_origin,       file, sizeof(uint16_t)); file += sizeof(uint16_t);
-    memcpy(&header.map_length,       file, sizeof(uint16_t)); file += sizeof(uint16_t);
-    memcpy(&header.map_depth,        file, sizeof( uint8_t)); file += sizeof( uint8_t);
-    memcpy(&header.image_x,          file, sizeof(uint16_t)); file += sizeof(uint16_t);
-    memcpy(&header.image_y,          file, sizeof(uint16_t)); file += sizeof(uint16_t);
-    memcpy(&header.image_width,      file, sizeof(uint16_t)); file += sizeof(uint16_t);
-    memcpy(&header.image_height,     file, sizeof(uint16_t)); file += sizeof(uint16_t);
-    memcpy(&header.image_depth,      file, sizeof( uint8_t)); file += sizeof( uint8_t);
-    memcpy(&header.image_descriptor, file, sizeof( uint8_t)); file += sizeof( uint8_t);
+    memcpy(&header.id_len,           data, sizeof( uint8_t)); data += sizeof( uint8_t);
+    memcpy(&header.map_included,     data, sizeof( uint8_t)); data += sizeof( uint8_t);
+    memcpy(&header.image_type,       data, sizeof( uint8_t)); data += sizeof( uint8_t);
+    memcpy(&header.map_origin,       data, sizeof(uint16_t)); data += sizeof(uint16_t);
+    memcpy(&header.map_length,       data, sizeof(uint16_t)); data += sizeof(uint16_t);
+    memcpy(&header.map_depth,        data, sizeof( uint8_t)); data += sizeof( uint8_t);
+    memcpy(&header.image_x,          data, sizeof(uint16_t)); data += sizeof(uint16_t);
+    memcpy(&header.image_y,          data, sizeof(uint16_t)); data += sizeof(uint16_t);
+    memcpy(&header.image_width,      data, sizeof(uint16_t)); data += sizeof(uint16_t);
+    memcpy(&header.image_height,     data, sizeof(uint16_t)); data += sizeof(uint16_t);
+    memcpy(&header.image_depth,      data, sizeof( uint8_t)); data += sizeof( uint8_t);
+    memcpy(&header.image_descriptor, data, sizeof( uint8_t)); data += sizeof( uint8_t);
 
     Fang_Image result = {.pixels = NULL};
 
@@ -131,8 +131,8 @@ Fang_TGALoad(
         goto Error_Allocation;
 
     /* Image ID and color map unused */
-    file += header.id_len;
-    file += header.map_length;
+    data += header.id_len;
+    data += header.map_length;
 
     if (rle)
     {
@@ -157,11 +157,11 @@ Fang_TGALoad(
 
                     memcpy(
                         dest + x * result.stride,
-                        file,
+                        data,
                         (size_t)(n * result.stride)
                     );
 
-                    file += n * result.stride;
+                    data += n * result.stride;
 
                     count -= n;
                     x     += n;
@@ -189,12 +189,12 @@ Fang_TGALoad(
                         break;
                 }
 
-                const uint8_t val = *file++;
+                const uint8_t val = *data++;
                 if (val & 0x80)
                 {
-                    memcpy(pixel, file, (size_t)result.stride);
+                    memcpy(pixel, data, (size_t)result.stride);
 
-                    file += result.stride;
+                    data += result.stride;
                     rep   = (val & 0x7F) + 1;
                 }
                 else
@@ -214,9 +214,9 @@ Fang_TGALoad(
 
         for (int h = 0; h < result.height; ++h)
         {
-            memcpy(dest, file, (size_t)result.pitch);
+            memcpy(dest, data, (size_t)result.pitch);
             dest += result.pitch;
-            file += result.pitch;
+            data += result.pitch;
         }
     }
 

--- a/Source/Platform/FangSDL_File.c
+++ b/Source/Platform/FangSDL_File.c
@@ -1,0 +1,117 @@
+// Copyright (C) 2021  Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+static inline char *
+FangSDL_GetResourcePath(
+    const char * const filename)
+{
+    SDL_assert(filename);
+
+    char * const base_path = SDL_GetBasePath();
+    const size_t full_len  = SDL_strlen(base_path) + SDL_strlen(filename);
+    char * const full_path = SDL_malloc(sizeof(char) * full_len + 1);
+    full_path[full_len] = '\0';
+
+    SDL_strlcpy(full_path, base_path, full_len + 1);
+    SDL_strlcat(full_path,  filename, full_len + 1);
+
+    SDL_free(base_path);
+    return full_path;
+}
+
+Fang_FileError
+Fang_LoadFile(
+    const char      * const filename,
+          Fang_File * const result)
+{
+    SDL_assert(filename);
+    SDL_assert(result);
+    SDL_assert(!result->data);
+    SDL_assert(!result->size);
+
+    Fang_FileError error = FANG_FILE_ERROR_NONE;
+
+    SDL_RWops * file = NULL;
+
+    char * const full_path = FangSDL_GetResourcePath(filename);
+    if (!full_path)
+        goto Error_CantOpen;
+
+    file = SDL_RWFromFile(full_path, "rb");
+    if (!file)
+        goto Error_CantOpen;
+
+    const int64_t size = SDL_RWsize(file);
+    if (size < 0)
+        goto Error_CantStat;
+
+    result->data = SDL_malloc((size_t)size);
+    result->size = (size_t)size;
+
+    if (!result->data)
+        goto Error_CantMake;
+
+    const size_t num_read = SDL_RWread(
+        file,
+        result->data,
+        sizeof(uint8_t),
+        (size_t)size
+    );
+
+    if (num_read / sizeof(uint8_t) != (size_t)size)
+        goto Error_CantRead;
+
+    SDL_RWclose(file);
+    SDL_free(full_path);
+    return FANG_FILE_ERROR_NONE;
+
+Error_CantOpen:
+    error = FANG_FILE_ERROR_CANT_OPEN;
+    goto Error;
+
+Error_CantStat:
+    error = FANG_FILE_ERROR_UNKNOWN_SIZE;
+    goto Error;
+
+Error_CantMake:
+    error = FANG_FILE_ERROR_BAD_ALLOCATION;
+    goto Error;
+
+Error_CantRead:
+    error = FANG_FILE_ERROR_BAD_READ;
+    goto Error;
+
+Error:
+    SDL_RWclose(file);
+    SDL_free(full_path);
+    SDL_free(result->data);
+
+    result->data = NULL;
+    result->size = 0;
+    return error;
+}
+
+void
+Fang_FreeFile(
+    Fang_File * const file)
+{
+    SDL_assert(file);
+    SDL_assert(file->data);
+    SDL_assert(file->size);
+
+    SDL_free(file->data);
+    file->data = NULL;
+    file->size = 0;
+}


### PR DESCRIPTION
Resolves #31 

## Description

Moves the file management calls to platform-dependent declarations inside the `Fang/` source folder. This will
allow the game to later manage resources on its own.

## Changes
- Change `Fang_Memory.c` to `Fang_File.c` and add `Fang_LoadFile()` / `Fang_FreeFile()` platform calls
- Move macro definitions to `Fang_Macros.c` 
- Add `Fang_Defines.c` for global definitions and tags (such as `FANG_PLATFORM_CALL`)
- Update variable naming in `Fang_TGALoad()`
- Remove underscore from `Fang_SDL.c`; platform files should follow the convention `Fang<PLATFORM>_<SUBJECT>.c`

