### PR TITLE
Normalize Dir+Cam Vectors When Rotating Camera

### DIFF
--- a/Source/Fang/Fang_Camera.c
+++ b/Source/Fang/Fang_Camera.c
@@ -40,6 +40,12 @@ Fang_CameraRotate(
     cam->x = cam->x * rotation.x - cam->y * rotation.y;
     cam->y = cam->x * rotation.y + cam->y * rotation.x;
     cam->z = clamp(cam->z + pitch, -1.0f, 1.0f);
+
+    *(Fang_Vec2*)dir = Fang_Vec2Normalize(*(Fang_Vec2*)dir);
+    *(Fang_Vec2*)cam = Fang_Vec2Normalize(*(Fang_Vec2*)cam);
+
+    cam->x *= 0.5f;
+    cam->y *= 0.5f;
 }
 
 static inline Fang_Rect

--- a/Source/Fang/Fang_Vector.c
+++ b/Source/Fang/Fang_Vector.c
@@ -52,3 +52,17 @@ Fang_Vec2Angle(
 {
     return atan2f(Fang_Vec2Dot(a, b), Fang_Vec2Determ(a, b));
 }
+
+static inline float
+Fang_Vec2Norm(
+    const Fang_Vec2 a)
+{
+    return sqrtf(a.x * a.x + a.y * a.y);
+}
+
+static inline Fang_Vec2
+Fang_Vec2Normalize(
+    const Fang_Vec2 a)
+{
+    return Fang_Vec2Divf(a, Fang_Vec2Norm(a));
+}


### PR DESCRIPTION
## Description

Without this, the camera widens out and creates some really wonky distortions the more it rotates. 
The effect is only noticeable after many rotations however, so it's not noticed in normal gameplay unless
the player is rotating in one direction often.

## Changes
- Normalizes the direction and camera plane vectors when rotating the camera

