### PR TITLE
Correct Calculations For Screen Projection

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -34,8 +34,8 @@
 #include "Fang_TGA.c"
 #include "Fang_Framebuffer.c"
 #include "Fang_Body.c"
-#include "Fang_Camera.c"
 #include "Fang_Tile.c"
+#include "Fang_Camera.c"
 #include "Fang_Textures.c"
 #include "Fang_Map.c"
 #include "Fang_Ray.c"
@@ -44,6 +44,7 @@
 #include "Fang_Interface.c"
 
 Fang_Interface interface = (Fang_Interface){
+    .textures = &temp_map.textures,
     .theme = (Fang_InterfaceTheme){
         .font = FANG_TEXTURE_FORMULA,
         .colors = (Fang_InterfaceColors){
@@ -61,7 +62,7 @@ Fang_Camera camera = (Fang_Camera){
     .pos = {
         .x = 32 * 2,
         .y = 32 * 2,
-        .z = 32 / 2,
+        .z = 0,
     },
     .dir = {.x = -1.0f},
     .cam = {.y =  0.5f},
@@ -126,12 +127,6 @@ Fang_Update(
     framebuf->state.current_depth = 0.0f;
     framebuf->state.enable_depth  = true;
 
-    Fang_CameraRotate(
-        &camera,
-        0.0075f,
-        0
-    );
-
     Fang_RayCast(
         &temp_map,
         &camera,
@@ -188,6 +183,51 @@ Fang_Update(
         FANG_FONT_HEIGHT,
         &(Fang_Point){.x = 5, .y = 3}
     );
+
+    static float height = 0.0f;
+    static float pitch  = 0.0f;
+    static float rotate = 0.0f;
+    static float move   = 0.0f;
+
+    if (Fang_InterfaceSlider(
+        &interface, &height, "height",
+        &(Fang_Rect){.x = 256 - 100, .w = 100, .h = 15}))
+    {
+        camera.pos.z = (height * 2.0f - 1.0f) * (32.0f);
+    }
+
+    if (Fang_InterfaceSlider(
+        &interface, &pitch, "pitch",
+        &(Fang_Rect){.x = 256 - 100, .y = 20, .w = 100, .h = 15}))
+    {
+        camera.cam.z = pitch * 2.0f - 1.0f;
+    }
+
+    if (Fang_InterfaceSlider(
+        &interface, &rotate, "rotate",
+        &(Fang_Rect){.x = 256 - 100, .y = 40, .w = 100, .h = 15}))
+    {
+        Fang_CameraRotate(
+            &camera,
+            (rotate * 2.0f - 1.0f) / 100.0f,
+            0
+        );
+    }
+
+    if (Fang_InterfaceSlider(
+        &interface, &move, "move",
+        &(Fang_Rect){.x = 256 - 100, .y = 60, .w = 100, .h = 15}))
+    {
+        const float vel = (move * 2.0f - 1.0f) * 0.5f;
+
+        Fang_Vec2 * const pos = (Fang_Vec2*)&camera.pos;
+        Fang_Vec3 * const dir = &camera.dir;
+
+        *pos = (Fang_Vec2){
+            .x = pos->x + (dir->x * vel),
+            .y = pos->y + (dir->y * vel),
+        };
+    }
 }
 
 static inline void

--- a/Source/Fang/Fang_Camera.c
+++ b/Source/Fang/Fang_Camera.c
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+const float FANG_PROJECTION_RATIO = 1.0f / 8.0f;
+
 typedef struct Fang_Camera {
     Fang_Vec3 pos;
     Fang_Vec3 dir;
@@ -48,34 +50,28 @@ Fang_CameraRotate(
     cam->y *= 0.5f;
 }
 
-static inline Fang_Rect
-Fang_CameraProjectSurface(
-    const Fang_Camera * const camera,
-    const Fang_Rect   * const surface,
-    const float               dist,
-    const int                 tile_size,
-    const Fang_Rect   * const viewport)
+static inline Fang_Tile
+Fang_CameraProjectTile(
+    const Fang_Camera   * const camera,
+    const Fang_Tile     * const tile,
+          float                 dist,
+    const Fang_Rect     * const viewport)
 {
     assert(camera);
-    assert(surface);
     assert(viewport);
 
-    const float ratio  = viewport->h / dist;
-    const float height = (surface->y / (float)tile_size) * ratio;
-    const float size   = (surface->h / (float)tile_size) * ratio - ratio;
+    /* Camera space to screen space */
+    dist = viewport->h / dist;
 
-    return (Fang_Rect){
-        .x = surface->x,
-        .y = (int)(
-            (viewport->h / 2)
-          - (ratio / 2.0f)
-          - height
-          - size
-          + (camera->cam.z * viewport->h)
-          + (camera->pos.z / dist)
-        ),
-        .w = surface->w,
-        .h = (int)(ratio + size),
+    /* Calculated positions in screen space */
+    const float offset = (tile->y       * FANG_PROJECTION_RATIO) * dist;
+    const float size   = (tile->h       * FANG_PROJECTION_RATIO) * dist - dist;
+    const float height = (camera->pos.z * FANG_PROJECTION_RATIO) * dist;
+    const float pitch  = (camera->cam.z * viewport->h);
+
+    return (Fang_Tile){
+        .y = (int)roundf((viewport->h / 2) - offset - size + height + pitch),
+        .h = (int)roundf(size),
     };
 }
 
@@ -84,7 +80,7 @@ Fang_CameraProjectBody(
     const Fang_Camera * const camera,
     const Fang_Body   * const body,
     const Fang_Rect   * const viewport,
-          float       * const out_dist)
+          float       * const out_depth)
 {
     assert(camera);
     assert(body);
@@ -94,32 +90,39 @@ Fang_CameraProjectBody(
         1.0f / (camera->cam.x * camera->dir.y - camera->dir.x * camera->cam.y)
     };
 
-    const Fang_Vec2 dist = {
+    const Fang_Vec2 pos = {
         .x = body->pos.x - camera->pos.x,
         .y = body->pos.y - camera->pos.y,
     };
 
+    /* Transform sprite with inverse camera matrix */
     const Fang_Vec2 transform = {
-        .x = inv_det * ( camera->dir.y * dist.x - camera->dir.x * dist.y),
-        .y = inv_det * (-camera->cam.y * dist.x + camera->cam.x * dist.y),
+        .x = inv_det * ( camera->dir.y * pos.x - camera->dir.x * pos.y),
+        .y = inv_det * (-camera->cam.y * pos.x + camera->cam.x * pos.y),
     };
-
-    *out_dist = transform.y;
 
     if (transform.y <= 0.0f)
         return (Fang_Rect){.h = 0};
 
-    const float size = (viewport->h / transform.y) * body->size;
+    *out_depth = 1.0f / transform.y;
+
+    /* Camera space to screen space */
+    const float dist   = (viewport->h   / transform.y);
+    const float size   = (body->size    * FANG_PROJECTION_RATIO) * dist;
+    const float offset = (camera->pos.z * FANG_PROJECTION_RATIO) * dist;
+    const float pitch  = (camera->cam.z * viewport->h);
 
     return (Fang_Rect){
         .x = (int)(
-            (viewport->w / 2.0f) * (1.0f - transform.x / transform.y)
+            (viewport->w / 2.0f)
+          * (1.0f - transform.x / transform.y)
           - (size / 2.0f)
         ),
         .y = (int)(
-            (viewport->h / 2.0f) - (size / 2.0f)
-          + (camera->cam.z * viewport->h)
-          + (camera->pos.z / transform.y)
+            (viewport->h / 2.0f)
+          - size
+          + offset
+          + pitch
         ),
         .w = (int)size,
         .h = (int)size,

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -22,7 +22,7 @@ typedef struct Fang_Map {
     Fang_Atlas textures;
 
     Fang_TileType * tiles;
-    Fang_TileSize * sizes;
+    Fang_Tile * sizes;
 
     Fang_Image skybox;
     Fang_Image floor;
@@ -37,7 +37,7 @@ enum {
 };
 
 Fang_TileType temp_map_map[temp_map_width][temp_map_height] = {
-    {1, 1, 1, 1, 1, 1, 1, 1},
+    {1, 1, 1, 0, 0, 0, 1, 1},
     {1, 0, 0, 0, 0, 0, 2, 1},
     {1, 0, 0, 0, 0, 0, 0, 1},
     {1, 0, 0, 0, 0, 0, 0, 1},
@@ -53,7 +53,7 @@ Fang_Map temp_map = {
     .height = temp_map_height,
     .tile_size = 16,
     .fog = FANG_BLACK,
-    .fog_distance = 4,
+    .fog_distance = 16,
 };
 
 static inline int
@@ -102,7 +102,7 @@ Fang_MapQueryType(
     return map->tiles[y * map->width + x];
 }
 
-static inline Fang_TileSize
+static inline Fang_Tile
 Fang_MapQuerySize(
     const Fang_Map * const map,
     const int x,
@@ -115,13 +115,13 @@ Fang_MapQuerySize(
     switch (type)
     {
         case FANG_TILETYPE_SOLID:
-            return (Fang_TileSize){0, map->tile_size};
+            return (Fang_Tile){0, map->tile_size};
 
         case FANG_TILETYPE_FLOATING:
-            return (Fang_TileSize){map->tile_size + 3, map->tile_size};
+            return (Fang_Tile){map->tile_size, map->tile_size};
 
         default:
-            return (Fang_TileSize){0, 0};
+            return (Fang_Tile){0, 0};
     }
 }
 

--- a/Source/Fang/Fang_Tile.c
+++ b/Source/Fang/Fang_Tile.c
@@ -21,7 +21,7 @@ typedef enum Fang_TileType {
     FANG_NUM_TILETYPE,
 } Fang_TileType;
 
-typedef struct Fang_TileSize {
-    int height;
-    int size;
-} Fang_TileSize;
+typedef struct Fang_Tile {
+    int y;
+    int h;
+} Fang_Tile;

--- a/Source/Fang/Fang_Vector.c
+++ b/Source/Fang/Fang_Vector.c
@@ -29,6 +29,14 @@ Fang_Vec2Divf(
     return (Fang_Vec2){a.x / b, a.y / b};
 }
 
+static inline Fang_Vec2
+Fang_Vec2Multf(
+    const Fang_Vec2 a,
+    const float     b)
+{
+    return (Fang_Vec2){a.x * b, a.y * b};
+}
+
 static inline float
 Fang_Vec2Dot(
     const Fang_Vec2 a,


### PR DESCRIPTION
Resolves #30 

## Description

Fixes various issues described in https://github.com/lassandroan/Fang/pull/29#discussion_r656689193

## Changes
- Ensures texture atlas is available for interface
- Adds a few UI-based controls for moving the camera
- Adds `FANG_PROJECTION_RATIO` constant, this is used when translating world coordinates into screen space
- Changes `Fang_TileSize` to just `Fang_Tile`, this will hold more tile information later on
- Renames `Fang_CameraProjectSurface()` to `Fang_CameraProjectTile()` and simplifies its calculations
- Cleans up `Fang_CameraProjectBody()` and improves clarity of variable names within
- Fixes perspective issues when rendering the map floor
- Fixes fog distance calculation when rendering the map floor
- Adds `Fang_Vec2Multf()`

