### PR TITLE
Move Grid Size Constants To Their Own File

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -61,8 +61,8 @@ Fang_Ray raycast[FANG_WINDOW_SIZE];
 
 Fang_Camera camera = (Fang_Camera){
     .pos = {
-        .x = 32 * 2,
-        .y = 32 * 2,
+        .x = 2,
+        .y = 2,
         .z = 0,
     },
     .dir = {.x = -1.0f},
@@ -76,14 +76,14 @@ enum {
 Fang_Entity entities[FANG_NUM_ENTITIES] = {
     [0] = (Fang_Entity){
         (Fang_Body){
-            .pos  = (Fang_Vec2){.x = 32, .y = 32},
-            .size = 16,
+            .pos  = (Fang_Vec2){.x = 2.0f, .y = 2.0f},
+            .size = 1,
         },
     },
     [1] = (Fang_Entity){
         (Fang_Body){
-            .pos  = (Fang_Vec2){.x = 96, .y = 84},
-            .size = 16,
+            .pos  = (Fang_Vec2){.x = 6.0f, .y = 5.5f},
+            .size = 1,
         },
     },
 };
@@ -194,7 +194,7 @@ Fang_Update(
         &interface, &height, "height",
         &(Fang_Rect){.x = 256 - 100, .w = 100, .h = 15}))
     {
-        camera.pos.z = (height * 2.0f - 1.0f) * (32.0f);
+        camera.pos.z = (height * 2.0f - 1.0f) * (1.0f);
     }
 
     if (Fang_InterfaceSlider(
@@ -219,7 +219,7 @@ Fang_Update(
         &interface, &move, "move",
         &(Fang_Rect){.x = 256 - 100, .y = 60, .w = 100, .h = 15}))
     {
-        const float vel = (move * 2.0f - 1.0f) * 0.5f;
+        const float vel = (move * 2.0f - 1.0f) * 0.05f;
 
         Fang_Vec2 * const pos = (Fang_Vec2*)&camera.pos;
         Fang_Vec3 * const dir = &camera.dir;

--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "Fang_Defines.c"
+#include "Fang_Constants.c"
 #include "Fang_Macros.c"
 #include "Fang_File.c"
 #include "Fang_Color.c"

--- a/Source/Fang/Fang_Camera.c
+++ b/Source/Fang/Fang_Camera.c
@@ -13,8 +13,6 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-const float FANG_PROJECTION_RATIO = 1.0f / 8.0f;
-
 typedef struct Fang_Camera {
     Fang_Vec3 pos;
     Fang_Vec3 dir;

--- a/Source/Fang/Fang_Constants.c
+++ b/Source/Fang/Fang_Constants.c
@@ -1,0 +1,17 @@
+// Copyright (C) 2021  Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+const int   FANG_GRID_SIZE        = 16;
+const float FANG_PROJECTION_RATIO = 1.0f / (FANG_GRID_SIZE / 2.0f);

--- a/Source/Fang/Fang_Constants.c
+++ b/Source/Fang/Fang_Constants.c
@@ -13,5 +13,4 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-const int   FANG_GRID_SIZE        = 16;
-const float FANG_PROJECTION_RATIO = 1.0f / (FANG_GRID_SIZE / 2.0f);
+const float FANG_PROJECTION_RATIO = 1.0f / (1.0f / 2.0f);

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -82,13 +82,10 @@ Fang_DestroyMap(void)
 static inline Fang_TileType
 Fang_MapQueryType(
     const Fang_Map * const map,
-    int x,
-    int y)
+    const int              x,
+    const int              y)
 {
     assert(map);
-
-    x /= FANG_GRID_SIZE;
-    y /= FANG_GRID_SIZE;
 
     if (x < 0 || x >= map->width)
         return FANG_TILETYPE_NONE;
@@ -102,8 +99,8 @@ Fang_MapQueryType(
 static inline Fang_Tile
 Fang_MapQuerySize(
     const Fang_Map * const map,
-    const int x,
-    const int y)
+    const int              x,
+    const int              y)
 {
     assert(map);
 
@@ -112,10 +109,10 @@ Fang_MapQuerySize(
     switch (type)
     {
         case FANG_TILETYPE_SOLID:
-            return (Fang_Tile){0, FANG_GRID_SIZE};
+            return (Fang_Tile){0, 1};
 
         case FANG_TILETYPE_FLOATING:
-            return (Fang_Tile){FANG_GRID_SIZE, FANG_GRID_SIZE};
+            return (Fang_Tile){1, 1};
 
         default:
             return (Fang_Tile){0, 0};
@@ -125,8 +122,8 @@ Fang_MapQuerySize(
 static inline const Fang_Image*
 Fang_MapQueryTexture(
     const Fang_Map * const map,
-    const int x,
-    const int y)
+    const int              x,
+    const int              y)
 {
     assert(map);
 

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -17,8 +17,6 @@ typedef struct Fang_Map {
     int width;
     int height;
 
-    int tile_size;
-
     Fang_Atlas textures;
 
     Fang_TileType * tiles;
@@ -51,7 +49,6 @@ Fang_Map temp_map = {
     .tiles = &temp_map_map[0][0],
     .width = temp_map_width,
     .height = temp_map_height,
-    .tile_size = 16,
     .fog = FANG_BLACK,
     .fog_distance = 16,
 };
@@ -90,8 +87,8 @@ Fang_MapQueryType(
 {
     assert(map);
 
-    x /= map->tile_size;
-    y /= map->tile_size;
+    x /= FANG_GRID_SIZE;
+    y /= FANG_GRID_SIZE;
 
     if (x < 0 || x >= map->width)
         return FANG_TILETYPE_NONE;
@@ -115,10 +112,10 @@ Fang_MapQuerySize(
     switch (type)
     {
         case FANG_TILETYPE_SOLID:
-            return (Fang_Tile){0, map->tile_size};
+            return (Fang_Tile){0, FANG_GRID_SIZE};
 
         case FANG_TILETYPE_FLOATING:
-            return (Fang_Tile){map->tile_size, map->tile_size};
+            return (Fang_Tile){FANG_GRID_SIZE, FANG_GRID_SIZE};
 
         default:
             return (Fang_Tile){0, 0};

--- a/Source/Fang/Fang_Ray.c
+++ b/Source/Fang/Fang_Ray.c
@@ -54,8 +54,7 @@ Fang_RayCast(
 
     const Fang_Vec3 * const dir = &camera->dir;
     const Fang_Vec3 * const cam = &camera->cam;
-
-    const Fang_Vec2 cam_pos = *(Fang_Vec2*)&camera->pos;
+    const Fang_Vec2         pos = (Fang_Vec2){camera->pos.x, camera->pos.y};
 
     memset(rays, 0, sizeof(Fang_Ray) * count);
 
@@ -79,9 +78,9 @@ Fang_RayCast(
                 : (cam_ray.y == 0.0f) ? 0.0f : fabsf(1.0f / cam_ray.y),
         };
 
-        Fang_Vec2 trunc_pos = {
-            .x = floorf(cam_pos.x),
-            .y = floorf(cam_pos.y),
+        Fang_Vec2 int_pos = {
+            .x = floorf(pos.x),
+            .y = floorf(pos.y),
         };
 
         Fang_Vec2 step_dist;
@@ -92,26 +91,26 @@ Fang_RayCast(
         if (cam_ray.x < 0.0f)
         {
             step_dist.x = -1.0f;
-            side_dist.x = (cam_pos.x - trunc_pos.x) * delta_dist.x;
+            side_dist.x = (pos.x - int_pos.x) * delta_dist.x;
             side_face_x  = FANG_FACE_EAST;
         }
         else
         {
             step_dist.x = 1.0f;
-            side_dist.x = (trunc_pos.x + 1.0f - cam_pos.x) * delta_dist.x;
+            side_dist.x = (int_pos.x + 1.0f - pos.x) * delta_dist.x;
             side_face_x  = FANG_FACE_WEST;
         }
 
         if (cam_ray.y < 0.0f)
         {
             step_dist.y = -1.0f;
-            side_dist.y = (cam_pos.y - trunc_pos.y) * delta_dist.y;
+            side_dist.y = (pos.y - int_pos.y) * delta_dist.y;
             side_face_y  = FANG_FACE_SOUTH;
         }
         else
         {
             step_dist.y = 1.0f;
-            side_dist.y = (trunc_pos.y + 1.0f - cam_pos.y) * delta_dist.y;
+            side_dist.y = (int_pos.y + 1.0f - pos.y) * delta_dist.y;
             side_face_y  = FANG_FACE_NORTH;
         }
 
@@ -123,13 +122,13 @@ Fang_RayCast(
 
             if (side_dist.x < side_dist.y)
             {
-                trunc_pos.x  += step_dist.x;
+                int_pos.x  += step_dist.x;
                 side_dist.x  += delta_dist.x;
                 hit->norm_dir = side_face_x;
             }
             else if (side_dist.x > side_dist.y)
             {
-                trunc_pos.y  += step_dist.y;
+                int_pos.y  += step_dist.y;
                 side_dist.y  += delta_dist.y;
                 hit->norm_dir = side_face_y;
             }
@@ -137,20 +136,20 @@ Fang_RayCast(
             {
                 if (step_dist.x < step_dist.y)
                 {
-                    trunc_pos.x  += step_dist.x;
+                    int_pos.x  += step_dist.x;
                     side_dist.x  += delta_dist.x;
                     hit->norm_dir = side_face_x;
                 }
                 else
                 {
-                    trunc_pos.y  += step_dist.y;
+                    int_pos.y  += step_dist.y;
                     side_dist.y  += delta_dist.y;
                     hit->norm_dir = side_face_y;
                 }
             }
 
             const Fang_TileType wall_type = Fang_MapQueryType(
-                map, (int)trunc_pos.x, (int)trunc_pos.y
+                map, (int)int_pos.x, (int)int_pos.y
             );
 
             if (wall_type)
@@ -159,7 +158,7 @@ Fang_RayCast(
                 if (hit->norm_dir == side_face_x)
                 {
                     hit->front_dist = (
-                        trunc_pos.x - cam_pos.x + (1.0f - step_dist.x) / 2.0f
+                        int_pos.x - pos.x + (1.0f - step_dist.x) / 2.0f
                     );
 
                     if (cam_ray.x != 0.0f)
@@ -168,7 +167,7 @@ Fang_RayCast(
                 else if (hit->norm_dir == side_face_y)
                 {
                     hit->front_dist = (
-                        trunc_pos.y - cam_pos.y + (1.0f - step_dist.y) / 2.0f
+                        int_pos.y - pos.y + (1.0f - step_dist.y) / 2.0f
                     );
 
                     if (cam_ray.y != 0.0f)
@@ -176,15 +175,15 @@ Fang_RayCast(
                 }
 
                 hit->tile_pos = (Fang_Point){
-                    (int)trunc_pos.x, (int)trunc_pos.y
+                    (int)int_pos.x, (int)int_pos.y
                 };
 
                 hit->front_hit = (Fang_Vec2){
-                    .x = camera->pos.x + (hit->front_dist * cam_ray.x),
-                    .y = camera->pos.y + (hit->front_dist * cam_ray.y),
+                    .x = pos.x + (hit->front_dist * cam_ray.x),
+                    .y = pos.y + (hit->front_dist * cam_ray.y),
                 };
 
-                const Fang_Vec2 old_trunc_pos = trunc_pos;
+                const Fang_Vec2 old_trunc_pos = int_pos;
                 const Fang_Vec2 old_side_dist = side_dist;
 
                 /* Run an additional increment to calculate the back face hit */
@@ -193,13 +192,13 @@ Fang_RayCast(
 
                     if (side_dist.x < side_dist.y)
                     {
-                        trunc_pos.x += step_dist.x;
+                        int_pos.x += step_dist.x;
                         side_dist.x += delta_dist.x;
                         face = side_face_x;
                     }
                     else if (side_dist.x > side_dist.y)
                     {
-                        trunc_pos.y += step_dist.y;
+                        int_pos.y += step_dist.y;
                         side_dist.y += delta_dist.y;
                         face = side_face_y;
                     }
@@ -207,13 +206,13 @@ Fang_RayCast(
                     {
                         if (step_dist.x < step_dist.y)
                         {
-                            trunc_pos.x += step_dist.x;
+                            int_pos.x += step_dist.x;
                             side_dist.x += delta_dist.x;
                             face = side_face_x;
                         }
                         else
                         {
-                            trunc_pos.y += step_dist.y;
+                            int_pos.y += step_dist.y;
                             side_dist.y += delta_dist.y;
                             face = side_face_y;
                         }
@@ -223,7 +222,7 @@ Fang_RayCast(
                     if (face == side_face_x)
                     {
                         hit->back_dist = (
-                            trunc_pos.x - cam_pos.x + (1.0f - step_dist.x) / 2.0f
+                            int_pos.x - pos.x + (1.0f - step_dist.x) / 2.0f
                         );
 
                         if (cam_ray.x != 0.0f)
@@ -232,7 +231,7 @@ Fang_RayCast(
                     else if (face == side_face_y)
                     {
                         hit->back_dist = (
-                            trunc_pos.y - cam_pos.y + (1.0f - step_dist.y) / 2.0f
+                            int_pos.y - pos.y + (1.0f - step_dist.y) / 2.0f
                         );
 
                         if (cam_ray.y != 0.0f)
@@ -240,12 +239,12 @@ Fang_RayCast(
                     }
 
                     hit->back_hit = (Fang_Vec2){
-                        .x = camera->pos.x + (hit->back_dist * cam_ray.x),
-                        .y = camera->pos.y + (hit->back_dist * cam_ray.y),
+                        .x = pos.x + (hit->back_dist * cam_ray.x),
+                        .y = pos.y + (hit->back_dist * cam_ray.y),
                     };
                 }
 
-                trunc_pos = old_trunc_pos;
+                int_pos = old_trunc_pos;
                 side_dist = old_side_dist;
 
                 hit_count++;

--- a/Source/Fang/Fang_Ray.c
+++ b/Source/Fang/Fang_Ray.c
@@ -56,8 +56,8 @@ Fang_RayCast(
     const Fang_Vec3 * const cam = &camera->cam;
 
     const Fang_Vec2 cam_pos = {
-        .x = camera->pos.x / map->tile_size,
-        .y = camera->pos.y / map->tile_size,
+        .x = camera->pos.x / FANG_GRID_SIZE,
+        .y = camera->pos.y / FANG_GRID_SIZE,
     };
 
     memset(rays, 0, sizeof(Fang_Ray) * count);
@@ -153,8 +153,8 @@ Fang_RayCast(
             }
 
             const Fang_Point tile_pos = {
-                .x = (int)(trunc_pos.x * map->tile_size),
-                .y = (int)(trunc_pos.y * map->tile_size),
+                .x = (int)(trunc_pos.x * FANG_GRID_SIZE),
+                .y = (int)(trunc_pos.y * FANG_GRID_SIZE),
             };
 
             const Fang_TileType wall_type = Fang_MapQueryType(
@@ -187,9 +187,9 @@ Fang_RayCast(
 
                 hit->front_hit = (Fang_Vec2){
                     .x = camera->pos.x + (hit->front_dist * cam_ray.x)
-                       * map->tile_size,
+                       * FANG_GRID_SIZE,
                     .y = camera->pos.y + (hit->front_dist * cam_ray.y)
-                       * map->tile_size,
+                       * FANG_GRID_SIZE,
                 };
 
                 const Fang_Vec2 old_trunc_pos = trunc_pos;
@@ -249,9 +249,9 @@ Fang_RayCast(
 
                     hit->back_hit = (Fang_Vec2){
                         .x = camera->pos.x + (hit->back_dist * cam_ray.x)
-                           * map->tile_size,
+                           * FANG_GRID_SIZE,
                         .y = camera->pos.y + (hit->back_dist * cam_ray.y)
-                           * map->tile_size,
+                           * FANG_GRID_SIZE,
                     };
                 }
 

--- a/Source/Fang/Fang_Ray.c
+++ b/Source/Fang/Fang_Ray.c
@@ -55,10 +55,7 @@ Fang_RayCast(
     const Fang_Vec3 * const dir = &camera->dir;
     const Fang_Vec3 * const cam = &camera->cam;
 
-    const Fang_Vec2 cam_pos = {
-        .x = camera->pos.x / FANG_GRID_SIZE,
-        .y = camera->pos.y / FANG_GRID_SIZE,
-    };
+    const Fang_Vec2 cam_pos = *(Fang_Vec2*)&camera->pos;
 
     memset(rays, 0, sizeof(Fang_Ray) * count);
 
@@ -152,13 +149,8 @@ Fang_RayCast(
                 }
             }
 
-            const Fang_Point tile_pos = {
-                .x = (int)(trunc_pos.x * FANG_GRID_SIZE),
-                .y = (int)(trunc_pos.y * FANG_GRID_SIZE),
-            };
-
             const Fang_TileType wall_type = Fang_MapQueryType(
-                map, tile_pos.x, tile_pos.y
+                map, (int)trunc_pos.x, (int)trunc_pos.y
             );
 
             if (wall_type)
@@ -183,13 +175,13 @@ Fang_RayCast(
                         hit->front_dist /= cam_ray.y;
                 }
 
-                hit->tile_pos = tile_pos;
+                hit->tile_pos = (Fang_Point){
+                    (int)trunc_pos.x, (int)trunc_pos.y
+                };
 
                 hit->front_hit = (Fang_Vec2){
-                    .x = camera->pos.x + (hit->front_dist * cam_ray.x)
-                       * FANG_GRID_SIZE,
-                    .y = camera->pos.y + (hit->front_dist * cam_ray.y)
-                       * FANG_GRID_SIZE,
+                    .x = camera->pos.x + (hit->front_dist * cam_ray.x),
+                    .y = camera->pos.y + (hit->front_dist * cam_ray.y),
                 };
 
                 const Fang_Vec2 old_trunc_pos = trunc_pos;
@@ -248,10 +240,8 @@ Fang_RayCast(
                     }
 
                     hit->back_hit = (Fang_Vec2){
-                        .x = camera->pos.x + (hit->back_dist * cam_ray.x)
-                           * FANG_GRID_SIZE,
-                        .y = camera->pos.y + (hit->back_dist * cam_ray.y)
-                           * FANG_GRID_SIZE,
+                        .x = camera->pos.x + (hit->back_dist * cam_ray.x),
+                        .y = camera->pos.y + (hit->back_dist * cam_ray.y),
                     };
                 }
 

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -448,9 +448,9 @@ Fang_DrawMapFloor(
         };
 
         Fang_Vec2 floor_pos = {
-            .x = (camera->pos.x / map->tile_size) / 2.0f
+            .x = (camera->pos.x / FANG_GRID_SIZE) / 2.0f
                + row_dist * ray_start.x,
-            .y = (camera->pos.y / map->tile_size) / 2.0f
+            .y = (camera->pos.y / FANG_GRID_SIZE) / 2.0f
                + row_dist * ray_start.y,
         };
 
@@ -581,8 +581,8 @@ Fang_DrawMapTiles(
 
                 float tex_x =
                     (face == FANG_FACE_NORTH || face == FANG_FACE_SOUTH)
-                        ? fmodf(face_hit.x, map->tile_size) / map->tile_size
-                        : fmodf(face_hit.y, map->tile_size) / map->tile_size;
+                        ? fmodf(face_hit.x, FANG_GRID_SIZE) / FANG_GRID_SIZE
+                        : fmodf(face_hit.y, FANG_GRID_SIZE) / FANG_GRID_SIZE;
 
                 tex_x = clamp(tex_x, 0.0f, 1.0f);
 
@@ -674,11 +674,11 @@ Fang_DrawMapTiles(
                     Fang_Point tex_pos;
                     {
                         Fang_Vec2 norm_hit_start = Fang_Vec2Divf(
-                            hit_start, map->tile_size
+                            hit_start, FANG_GRID_SIZE
                         );
 
                         Fang_Vec2 norm_hit_end = Fang_Vec2Divf(
-                            hit_end, map->tile_size
+                            hit_end, FANG_GRID_SIZE
                         );
 
                         float u = ((1.0f - r_y) * norm_hit_start.x)
@@ -808,8 +808,8 @@ Fang_DrawMinimap(
                 framebuf, (int)(colf * framebuf->color.width), &FANG_GREY
             );
 
-            const int x = row * map->tile_size;
-            const int y = col * map->tile_size;
+            const int x = row * FANG_GRID_SIZE;
+            const int y = col * FANG_GRID_SIZE;
 
             if (!Fang_MapQueryType(map, x, y))
                 continue;
@@ -831,10 +831,10 @@ Fang_DrawMinimap(
 
     const Fang_Point camera_pos = {
         .x = (int)(
-            camera->pos.x / (float)(map->tile_size * map->width) * bounds.w
+            camera->pos.x / (float)(FANG_GRID_SIZE * map->width) * bounds.w
         ),
         .y = (int)(
-            camera->pos.y / (float)(map->tile_size * map->height) * bounds.h
+            camera->pos.y / (float)(FANG_GRID_SIZE * map->height) * bounds.h
         ),
     };
 
@@ -849,10 +849,10 @@ Fang_DrawMinimap(
             &camera_pos,
             &(Fang_Point){
                 .x = (int)(
-                    ray_pos.x / (float)(map->tile_size * map->width) * bounds.w
+                    ray_pos.x / (float)(FANG_GRID_SIZE * map->width) * bounds.w
                 ),
                 .y = (int)(
-                    ray_pos.y / (float)(map->tile_size * map->height) * bounds.h
+                    ray_pos.y / (float)(FANG_GRID_SIZE * map->height) * bounds.h
                 ),
             },
             &FANG_BLUE

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -439,9 +439,7 @@ Fang_DrawMapFloor(
         /* Calculate row distance, based on perspective at our given height */
         float row_dist = ((viewport.h / 2.0f) / p) / (1.0f / height);
 
-        framebuf->state.current_depth = row_dist
-                                      * height
-                                      * (1.0f / FANG_PROJECTION_RATIO);
+        framebuf->state.current_depth = row_dist * FANG_PROJECTION_RATIO;
 
         const Fang_Vec2 floor_step = {
             .x = row_dist * (ray_end.x - ray_start.x) / viewport.w,
@@ -770,12 +768,7 @@ Fang_DrawMap(
         Fang_DrawMapSkybox(framebuf, map, camera);
 
     if (map->floor.pixels)
-    {
-        const Fang_FrameState state = framebuf->state;
-        framebuf->state.enable_depth = false;
         Fang_DrawMapFloor(framebuf, map, camera);
-        framebuf->state = state;
-    }
 
     Fang_DrawMapTiles(framebuf, map, camera, rays, count);
 }

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -835,31 +835,36 @@ Fang_DrawMinimap(
         .y = (int)((camera->pos.y / map->height) * bounds.h),
     };
 
-    for (size_t i = 0; i < count; ++i)
+
+    if ((camera_pos.x >= 0 || camera_pos.x < bounds.w)
+    ||  (camera_pos.y >= 0 || camera_pos.y < bounds.h))
     {
-        const Fang_Ray * const ray = &rays[i];
+        for (size_t i = 0; i < count; ++i)
+        {
+            const Fang_Ray * const ray = &rays[i];
 
-        if (!ray->hit_count)
-            continue;
+            if (!ray->hit_count)
+                continue;
 
-        const Fang_Vec2 ray_pos = ray->hits[ray->hit_count - 1].front_hit;
+            const Fang_Vec2 ray_pos = ray->hits[ray->hit_count - 1].back_hit;
 
-        Fang_DrawLine(
-            framebuf,
-            &camera_pos,
-            &(Fang_Point){
-                .x = (int)((ray_pos.x / map->width) * bounds.w),
-                .y = (int)((ray_pos.y / map->height) * bounds.h),
-            },
-            &FANG_BLUE
-        );
+            Fang_DrawLine(
+                framebuf,
+                &camera_pos,
+                &(Fang_Point){
+                    .x = (int)((ray_pos.x / map->width) * bounds.w),
+                    .y = (int)((ray_pos.y / map->height) * bounds.h),
+                },
+                &FANG_BLUE
+            );
+        }
     }
 
     Fang_FillRect(
         framebuf,
         &(Fang_Rect){
-            .x = camera_pos.x - 5,
-            .y = camera_pos.y - 5,
+            .x = clamp(camera_pos.x, 0, bounds.w)  - 5,
+            .y = clamp(camera_pos.y, 0, bounds.h) - 5,
             .w = 10,
             .h = 10,
         },


### PR DESCRIPTION
Resolves #39 

## Description

Moves `tile_size` back out to its own constant, in a new `Fang_Constants.c` file

## Changes
- Removes `Fang_Map.tile_size`
- Adds `Fang_Constants.c` and moves `FANG_PROJECTION_RATIO` to it
- Removes tile size constant, world units (i.e. meters) will be the main unit
- Culls projected tiles that are outside of the viewport
- Culls pixel rows from tile top/bottom drawing when they're outside the viewport
- Fixes issues with positions and ray drawing in minimap

