### PR TITLE
Update Map Size And Querying

### DIFF
--- a/Source/Fang/Fang_Camera.c
+++ b/Source/Fang/Fang_Camera.c
@@ -48,7 +48,7 @@ Fang_CameraRotate(
     cam->y *= 0.5f;
 }
 
-static inline Fang_Tile
+static inline Fang_Rect
 Fang_CameraProjectTile(
     const Fang_Camera   * const camera,
     const Fang_Tile     * const tile,
@@ -65,7 +65,7 @@ Fang_CameraProjectTile(
     const float height = (camera->pos.z * FANG_PROJECTION_RATIO) * dist;
     const float pitch  = (camera->cam.z * viewport->h);
 
-    return (Fang_Tile){
+    return (Fang_Rect){
         .y = (int)roundf((viewport->h / 2) - offset - size + height + pitch),
         .h = (int)roundf(size),
     };

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -14,8 +14,7 @@
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 typedef struct Fang_Map {
-    int width;
-    int height;
+    int size;
 
     Fang_Atlas textures;
 
@@ -30,11 +29,10 @@ typedef struct Fang_Map {
 } Fang_Map;
 
 enum {
-    temp_map_width  = 8,
-    temp_map_height = 8,
+    temp_map_size = 8,
 };
 
-Fang_TileType temp_map_map[temp_map_width][temp_map_height] = {
+Fang_TileType temp_map_map[temp_map_size][temp_map_size] = {
     {1, 1, 1, 0, 0, 0, 1, 1},
     {1, 0, 0, 0, 0, 0, 2, 1},
     {1, 0, 0, 0, 0, 0, 0, 1},
@@ -47,8 +45,7 @@ Fang_TileType temp_map_map[temp_map_width][temp_map_height] = {
 
 Fang_Map temp_map = {
     .tiles = &temp_map_map[0][0],
-    .width = temp_map_width,
-    .height = temp_map_height,
+    .size = temp_map_size,
     .fog = FANG_BLACK,
     .fog_distance = 16,
 };
@@ -87,13 +84,13 @@ Fang_MapQueryType(
 {
     assert(map);
 
-    if (x < 0 || x >= map->width)
+    if (x < 0 || x >= map->size)
         return FANG_TILETYPE_NONE;
 
-    if (y < 0 || y >= map->height)
+    if (y < 0 || y >= map->size)
         return FANG_TILETYPE_NONE;
 
-    return map->tiles[y * map->width + x];
+    return map->tiles[y * map->size + x];
 }
 
 static inline Fang_Tile

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -76,56 +76,43 @@ Fang_DestroyMap(void)
     Fang_AtlasFree(&temp_map.textures);
 }
 
-static inline Fang_TileType
-Fang_MapQueryType(
+static inline const Fang_Tile *
+Fang_MapQuery(
     const Fang_Map * const map,
     const int              x,
     const int              y)
 {
     assert(map);
+
+    static const Fang_Tile solid_tile = {
+        .texture = FANG_TEXTURE_TILE,
+        .y = 0.0f,
+        .h = 1.0f,
+    };
+
+    static const Fang_Tile floating_tile = {
+        .texture = FANG_TEXTURE_TILE,
+        .y = 1.0f,
+        .h = 1.0f,
+    };
 
     if (x < 0 || x >= map->size)
-        return FANG_TILETYPE_NONE;
+        return NULL;
 
     if (y < 0 || y >= map->size)
-        return FANG_TILETYPE_NONE;
+        return NULL;
 
-    return map->tiles[y * map->size + x];
-}
-
-static inline Fang_Tile
-Fang_MapQuerySize(
-    const Fang_Map * const map,
-    const int              x,
-    const int              y)
-{
-    assert(map);
-
-    const Fang_TileType type = Fang_MapQueryType(map, x, y);
+    const Fang_TileType type = map->tiles[y * map->size + x];
 
     switch (type)
     {
         case FANG_TILETYPE_SOLID:
-            return (Fang_Tile){0, 1};
+            return &solid_tile;
 
         case FANG_TILETYPE_FLOATING:
-            return (Fang_Tile){1, 1};
+            return &floating_tile;
 
         default:
-            return (Fang_Tile){0, 0};
+            return NULL;
     }
-}
-
-static inline const Fang_Image*
-Fang_MapQueryTexture(
-    const Fang_Map * const map,
-    const int              x,
-    const int              y)
-{
-    assert(map);
-
-    (void)x;
-    (void)y;
-
-    return Fang_AtlasQuery(&map->textures, FANG_TEXTURE_TILE);
 }

--- a/Source/Fang/Fang_Ray.c
+++ b/Source/Fang/Fang_Ray.c
@@ -27,11 +27,11 @@ typedef enum Fang_Face {
 } Fang_Face;
 
 typedef struct Fang_RayHit {
+    const Fang_Tile * tile;
     Fang_Vec2  front_hit;
     float      front_dist;
     Fang_Vec2  back_hit;
     float      back_dist;
-    Fang_Point tile_pos;
     Fang_Face  norm_dir;
 } Fang_RayHit;
 
@@ -148,11 +148,9 @@ Fang_RayCast(
                 }
             }
 
-            const Fang_TileType wall_type = Fang_MapQueryType(
-                map, (int)int_pos.x, (int)int_pos.y
-            );
+            hit->tile = Fang_MapQuery(map, (int)int_pos.x, (int)int_pos.y);
 
-            if (wall_type)
+            if (hit->tile)
             {
                 /* Check the axis of collision */
                 if (hit->norm_dir == side_face_x)
@@ -173,10 +171,6 @@ Fang_RayCast(
                     if (cam_ray.y != 0.0f)
                         hit->front_dist /= cam_ray.y;
                 }
-
-                hit->tile_pos = (Fang_Point){
-                    (int)int_pos.x, (int)int_pos.y
-                };
 
                 hit->front_hit = (Fang_Vec2){
                     .x = pos.x + (hit->front_dist * cam_ray.x),

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -796,17 +796,17 @@ Fang_DrawMinimap(
 
     Fang_FillRect(framebuf, &bounds, &FANG_BLACK);
 
-    for (int row = 0; row < map->height; ++row)
+    for (int row = 0; row < map->size; ++row)
     {
-        const float rowf = (float)row / (float)map->height;
+        const float rowf = (float)row / (float)map->size;
 
         Fang_DrawHorizontalLine(
             framebuf, (int)(rowf * framebuf->color.height), &FANG_GREY
         );
 
-        for (int col = 0; col < map->width; ++col)
+        for (int col = 0; col < map->size; ++col)
         {
-            const float colf = col / (float)map->width;
+            const float colf = col / (float)map->size;
 
             Fang_DrawVerticalLine(
                 framebuf, (int)(colf * framebuf->color.width), &FANG_GREY
@@ -831,8 +831,8 @@ Fang_DrawMinimap(
     }
 
     const Fang_Point camera_pos = {
-        .x = (int)((camera->pos.x / map->width) * bounds.w),
-        .y = (int)((camera->pos.y / map->height) * bounds.h),
+        .x = (int)((camera->pos.x / map->size) * bounds.w),
+        .y = (int)((camera->pos.y / map->size) * bounds.h),
     };
 
 
@@ -852,8 +852,8 @@ Fang_DrawMinimap(
                 framebuf,
                 &camera_pos,
                 &(Fang_Point){
-                    .x = (int)((ray_pos.x / map->width) * bounds.w),
-                    .y = (int)((ray_pos.y / map->height) * bounds.h),
+                    .x = (int)((ray_pos.x / map->size) * bounds.w),
+                    .y = (int)((ray_pos.y / map->size) * bounds.h),
                 },
                 &FANG_BLUE
             );

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -526,18 +526,14 @@ Fang_DrawMapTiles(
         {
             const Fang_RayHit * const hit = &ray->hits[j];
 
+            if (!hit->tile)
+                continue;
+
             if (hit->front_dist <= 0.0f)
                 continue;
 
-            if (!Fang_MapQueryType(map, hit->tile_pos.x, hit->tile_pos.y))
-                continue;
-
-            const Fang_Tile tile = Fang_MapQuerySize(
-                map, hit->tile_pos.x, hit->tile_pos.y
-            );
-
-            const Fang_Image * const wall_tex = Fang_MapQueryTexture(
-                map, hit->tile_pos.x, hit->tile_pos.y
+            const Fang_Image * const wall_tex = Fang_AtlasQuery(
+                &map->textures, hit->tile->texture
             );
 
             Fang_Rect front_face;
@@ -550,16 +546,12 @@ Fang_DrawMapTiles(
                     ? hit->front_dist
                     : hit->back_dist;
 
-                const Fang_Tile projected_tile = Fang_CameraProjectTile(
-                    camera, &tile, face_dist, &viewport
+                Fang_Rect dest_rect = Fang_CameraProjectTile(
+                    camera, hit->tile, face_dist, &viewport
                 );
 
-                const Fang_Rect dest_rect = {
-                    .x = (int)i,
-                    .y = projected_tile.y,
-                    .w = 1,
-                    .h = projected_tile.h,
-                };
+                dest_rect.x = (int)i;
+                dest_rect.w = 1;
 
                 if (k == 0)
                     front_face = dest_rect;
@@ -812,7 +804,7 @@ Fang_DrawMinimap(
                 framebuf, (int)(colf * framebuf->color.width), &FANG_GREY
             );
 
-            if (!Fang_MapQueryType(map, row, col))
+            if (!Fang_MapQuery(map, row, col))
                 continue;
 
             Fang_Rect map_tile_bounds = Fang_RectResize(

--- a/Source/Fang/Fang_Tile.c
+++ b/Source/Fang/Fang_Tile.c
@@ -22,6 +22,7 @@ typedef enum Fang_TileType {
 } Fang_TileType;
 
 typedef struct Fang_Tile {
-    int y;
-    int h;
+    uint8_t texture;
+    float y;
+    float h;
 } Fang_Tile;


### PR DESCRIPTION
## Description

Simplifies a bit of the map structure and updates tile handling to 
be closer to what we'll be using once map files are implemented.

## Changes
- Replaces map `width` and `height` with a single size 
- Updates `Fang_Tile.y`, `Fang_Tile.h` to `float` from `int`
- Adds `Fang_Tile.texture` index value
- Updates map query function to `Fang_MapQuery()` that returns `Fang_Tile*`
- Removes `Fang_MapQuerySize()`, `Fang_MapQueryTexture()`
- Replaces `Fang_RayHit.tile_pos` with a `Fang_Tile*`, which removes the need for re-querying the map data
- Updates `Fang_CameraProjectTile()` to return a rectangle, since we need integer positions. The x/w values will be the responsibility of the caller

