### PR TITLE
Add Entity Physics & Player Controlling

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -136,11 +136,9 @@ Fang_Update(
             move.y -= 1.0f;
 
         if (Fang_InputPressed(&input->controller.action_down))
-        {
-            if (gamestate.player.body.pos.z <= gamestate.player.body.size)
-                move.z = FANG_JUMP_SPEED;
-        }
-        else if (input->controller.joystick_left.button.pressed)
+            move.z = FANG_JUMP_SPEED;
+
+        if (input->controller.joystick_left.button.pressed)
         {
             gamestate.player.body.max.x = FANG_RUN_SPEED * 1.5f;
             gamestate.player.body.max.y = FANG_RUN_SPEED * 1.5f;
@@ -184,6 +182,7 @@ Fang_Update(
         {
             Fang_BodyMove(
                 &gamestate.player.body,
+                &gamestate.map,
                 &move,
                 (float)update_dt / 1000.0f
             );

--- a/Source/Fang/Fang_Body.c
+++ b/Source/Fang/Fang_Body.c
@@ -13,7 +13,95 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * A structure representing a physical body in the game world.
+ *
+ * Body positions represent the bottom of the body, so effectively the "head"
+ * would be at Fang_Body.pos.z + Fang_Body.size.
+**/
 typedef struct Fang_Body {
-    Fang_Vec2 pos;
-    float     size;
+    Fang_Vec3 pos;  /* Current Position     */
+    Fang_Vec3 dir;  /* Current Direction    */
+    Fang_Vec3 vel;  /* Current Velocity     */
+    Fang_Vec2 acc;  /* Acceleration Speeds  */
+    Fang_Vec3 max;  /* Max Velocity Values  */
+    float     size; /* Body Size (All Axes) */
 } Fang_Body;
+
+/**
+ * Moves a body using a given 'move' vector.
+ *
+ * The X and Y values of the move vector will be multiplied with the body's
+ * acceleration values to determine the increase/decrease in velocity.
+ *
+ * The Z value of the move vector will be directly applied as the body's new
+ * Z velocity.
+ *
+ * If the movement vector is 0.0f for X/Y, the current velocities for those axes
+ * will be decreased until they reach 0.0f. The same applies to the Z axis, but
+ * instead it is gravity acting on the body if its position is above the floor.
+ *
+ * If the body is in the air, deceleration in the X/Y axes will not occur.
+**/
+static void
+Fang_BodyMove(
+          Fang_Body * const body,
+    const Fang_Vec3 * const move,
+    const float             delta)
+{
+    assert(body);
+    assert(move);
+
+    if (body->pos.z <= 0.0f)
+    {
+        for (size_t i = 0; i < 2; ++i)
+        {
+            float * const target = &body->vel.xyz[i];
+
+            if (fabsf(move->xyz[i]) < FLT_EPSILON)
+            {
+                const float delta_acc = body->acc.xy[i] * delta;
+
+                if (*target < 0.0f)
+                {
+                    if (*target + delta_acc < 0.0f)
+                        *target += delta_acc;
+                    else
+                        *target = 0.0f;
+                }
+                else if (*target > 0.0f)
+                {
+                    if (*target - delta_acc > 0.0f)
+                        *target -= delta_acc;
+                    else
+                        *target = 0.0f;
+                }
+            }
+
+            *target = clamp(
+                *target + ((body->acc.xy[i] * delta) * move->xyz[i]),
+                -body->max.xyz[i],
+                body->max.xyz[i]
+            );
+        }
+    }
+
+    if (fabsf(move->z) > FLT_EPSILON)
+        body->vel.z = move->z;
+    else
+        body->vel.z -= FANG_GRAVITY * delta;
+
+    if (body->pos.z + (body->vel.z * delta) <= 0.0f)
+    {
+        body->vel.z = 0.0f;
+        body->pos.z = 0.0f;
+    }
+
+    body->pos.x += (body->dir.x * body->vel.x + body->dir.y * body->vel.y)
+                 * delta;
+
+    body->pos.y += (body->dir.y * body->vel.x - body->dir.x * body->vel.y)
+                 * delta;
+
+    body->pos.z += body->vel.z * delta;
+}

--- a/Source/Fang/Fang_Camera.c
+++ b/Source/Fang/Fang_Camera.c
@@ -55,7 +55,7 @@ Fang_CameraProjectTile(
     dist = viewport->h / dist;
 
     const float offset = (tile->y       * FANG_PROJECTION_RATIO) * dist;
-    const float size   = (tile->h       * FANG_PROJECTION_RATIO) * dist - dist;
+    const float size   = (tile->h       * FANG_PROJECTION_RATIO) * dist;
     const float height = (camera->pos.z * FANG_PROJECTION_RATIO) * dist;
     const float pitch  = (camera->cam.z * viewport->h);
 

--- a/Source/Fang/Fang_Camera.c
+++ b/Source/Fang/Fang_Camera.c
@@ -32,20 +32,14 @@ Fang_CameraRotate(
         .y = sinf(angle),
     };
 
-    Fang_Vec3 * const dir = &camera->dir;
-    Fang_Vec3 * const cam = &camera->cam;
+    const Fang_Vec3 dir = camera->dir;
+    const Fang_Vec3 cam = camera->cam;
 
-    dir->x = dir->x * rotation.x - dir->y * rotation.y;
-    dir->y = dir->x * rotation.y + dir->y * rotation.x;
-    cam->x = cam->x * rotation.x - cam->y * rotation.y;
-    cam->y = cam->x * rotation.y + cam->y * rotation.x;
-    cam->z = clamp(cam->z + pitch, -1.0f, 1.0f);
-
-    *(Fang_Vec2*)dir = Fang_Vec2Normalize(*(Fang_Vec2*)dir);
-    *(Fang_Vec2*)cam = Fang_Vec2Normalize(*(Fang_Vec2*)cam);
-
-    cam->x *= 0.5f;
-    cam->y *= 0.5f;
+    camera->dir.x = dir.x * rotation.x - dir.y * rotation.y;
+    camera->dir.y = dir.x * rotation.y + dir.y * rotation.x;
+    camera->cam.x = cam.x * rotation.x - cam.y * rotation.y;
+    camera->cam.y = cam.x * rotation.y + cam.y * rotation.x;
+    camera->cam.z = clamp(camera->cam.z + pitch, -1.0f, 1.0f);
 }
 
 static inline Fang_Rect

--- a/Source/Fang/Fang_Constants.c
+++ b/Source/Fang/Fang_Constants.c
@@ -17,5 +17,5 @@ const float FANG_PROJECTION_RATIO = 1.0f / (1.0f / 2.0f);
 
 const float FANG_GRAVITY     = 9.834f;
 const float FANG_RUN_SPEED   = 8.33f; // 30 km/h ~= 8.33 m/s
-const float FANG_JUMP_SPEED  = 2.0f;
-const float FANG_PLAYER_SIZE = 0.25f;
+const float FANG_JUMP_SPEED  = 3.0f;
+const float FANG_PLAYER_SIZE = 0.3f;

--- a/Source/Fang/Fang_Constants.c
+++ b/Source/Fang/Fang_Constants.c
@@ -14,3 +14,8 @@
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 const float FANG_PROJECTION_RATIO = 1.0f / (1.0f / 2.0f);
+
+const float FANG_GRAVITY     = 9.834f;
+const float FANG_RUN_SPEED   = 8.33f; // 30 km/h ~= 8.33 m/s
+const float FANG_JUMP_SPEED  = 2.0f;
+const float FANG_PLAYER_SIZE = 0.25f;

--- a/Source/Fang/Fang_Entity.c
+++ b/Source/Fang/Fang_Entity.c
@@ -13,6 +13,10 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+enum {
+    FANG_MAX_ENTITIES = 2,
+};
+
 typedef struct Fang_Entity {
     Fang_Body body;
 } Fang_Entity;

--- a/Source/Fang/Fang_Image.c
+++ b/Source/Fang/Fang_Image.c
@@ -102,11 +102,10 @@ Fang_ImageQuery(
     const Fang_Image * const image,
     const Fang_Point * const point)
 {
-    assert(image);
     assert(point);
 
     /* The 'XOR Texture' serves as the default 'missing' texture. */
-    if (!image->pixels)
+    if (!image || !image->pixels)
     {
         const uint8_t value = (uint8_t)point->x ^ (uint8_t)point->y;
         return (Fang_Color){value, value, value, 255};

--- a/Source/Fang/Fang_Image.c
+++ b/Source/Fang/Fang_Image.c
@@ -24,6 +24,20 @@ typedef struct Fang_Image {
     int       stride;
 } Fang_Image;
 
+static inline bool
+Fang_ImageValid(
+    const Fang_Image * const image)
+{
+    return (
+        image
+     && image->pixels
+     && image->width
+     && image->height
+     && image->stride
+     && image->pitch
+    );
+}
+
 /**
  * Sets the image attributes and allocates a pixel buffer for the image.
  *
@@ -62,8 +76,7 @@ static inline void
 Fang_ImageFree(
     Fang_Image * const image)
 {
-    assert(image);
-    assert(image->pixels);
+    assert(Fang_ImageValid(image));
 
     free(image->pixels);
     memset(image, 0, sizeof(Fang_Image));
@@ -81,14 +94,9 @@ static inline void
 Fang_ImageClear(
     Fang_Image * const image)
 {
-    assert(image);
-    assert(image->pixels);
+    assert(Fang_ImageValid(image));
 
-    memset(
-        (void*)image->pixels,
-        0,
-        (size_t)(image->pitch * image->height)
-    );
+    memset((void*)image->pixels, 0, (size_t)(image->pitch * image->height));
 }
 
 /**
@@ -105,7 +113,7 @@ Fang_ImageQuery(
     assert(point);
 
     /* The 'XOR Texture' serves as the default 'missing' texture. */
-    if (!image || !image->pixels)
+    if (!Fang_ImageValid(image))
     {
         const uint8_t value = (uint8_t)point->x ^ (uint8_t)point->y;
         return (Fang_Color){value, value, value, 255};

--- a/Source/Fang/Fang_Input.c
+++ b/Source/Fang/Fang_Input.c
@@ -160,6 +160,12 @@ Fang_InputReset(
 {
     assert(input);
 
+    input->mouse.left.transitions = 0;
+    input->mouse.right.transitions = 0;
+    input->mouse.middle.transitions = 0;
+    input->mouse.relative.x = 0;
+    input->mouse.relative.y = 0;
+
     input->controller.start.transitions = 0;
     input->controller.back.transitions = 0;
     input->controller.joystick_left.button.transitions = 0;

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -39,13 +39,13 @@ Fang_MapQuery(
     static const Fang_Tile solid_tile = {
         .texture = FANG_TEXTURE_TILE,
         .y = 0.0f,
-        .h = 1.0f,
+        .h = 0.1f,
     };
 
     static const Fang_Tile floating_tile = {
         .texture = FANG_TEXTURE_TILE,
-        .y = 1.0f,
-        .h = 1.0f,
+        .y = 0.0f,
+        .h = 0.2f,
     };
 
     if (x < 0 || x >= map->size)

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -16,65 +16,14 @@
 typedef struct Fang_Map {
     int size;
 
-    Fang_Atlas textures;
+    Fang_Tile * tiles;
 
-    Fang_TileType * tiles;
-    Fang_Tile * sizes;
-
-    Fang_Image skybox;
-    Fang_Image floor;
+    Fang_Texture skybox;
+    Fang_Texture floor;
 
     Fang_Color fog;
     float      fog_distance;
 } Fang_Map;
-
-enum {
-    temp_map_size = 8,
-};
-
-Fang_TileType temp_map_map[temp_map_size][temp_map_size] = {
-    {1, 1, 1, 0, 0, 0, 1, 1},
-    {1, 0, 0, 0, 0, 0, 2, 1},
-    {1, 0, 0, 0, 0, 0, 0, 1},
-    {1, 0, 0, 0, 0, 0, 0, 1},
-    {1, 2, 0, 0, 0, 0, 0, 1},
-    {1, 0, 0, 0, 0, 1, 0, 1},
-    {1, 1, 0, 0, 0, 0, 0, 1},
-    {1, 1, 1, 1, 1, 1, 1, 1},
-};
-
-Fang_Map temp_map = {
-    .tiles = &temp_map_map[0][0],
-    .size = temp_map_size,
-    .fog = FANG_BLACK,
-    .fog_distance = 16,
-};
-
-static inline int
-Fang_LoadMap(void)
-{
-    assert(!temp_map.skybox.pixels);
-    assert(!temp_map.floor.pixels);
-
-    for (Fang_Texture i = 0; i < FANG_NUM_TEXTURES; ++i)
-        Fang_AtlasLoad(&temp_map.textures, i);
-
-    temp_map.skybox = *Fang_AtlasQuery(
-        &temp_map.textures, FANG_TEXTURE_SKYBOX
-    );
-
-    temp_map.floor = *Fang_AtlasQuery(
-        &temp_map.textures, FANG_TEXTURE_FLOOR
-    );
-
-    return 0;
-}
-
-static inline void
-Fang_DestroyMap(void)
-{
-    Fang_AtlasFree(&temp_map.textures);
-}
 
 static inline const Fang_Tile *
 Fang_MapQuery(
@@ -83,6 +32,9 @@ Fang_MapQuery(
     const int              y)
 {
     assert(map);
+
+    /* NOTE: Temporary */
+    assert(map->size == 8);
 
     static const Fang_Tile solid_tile = {
         .texture = FANG_TEXTURE_TILE,
@@ -102,7 +54,18 @@ Fang_MapQuery(
     if (y < 0 || y >= map->size)
         return NULL;
 
-    const Fang_TileType type = map->tiles[y * map->size + x];
+    static const Fang_TileType temp_tiles[8 * 8] = {
+        1, 1, 1, 0, 0, 0, 1, 1,
+        1, 0, 0, 0, 0, 0, 2, 1,
+        1, 0, 0, 0, 0, 0, 0, 1,
+        1, 0, 0, 0, 0, 0, 0, 1,
+        1, 2, 0, 0, 0, 0, 0, 1,
+        1, 0, 0, 0, 0, 1, 0, 1,
+        1, 1, 0, 0, 0, 0, 0, 1,
+        1, 1, 1, 1, 1, 1, 1, 1,
+    };
+
+    const Fang_TileType type = temp_tiles[y * 8 + x];
 
     switch (type)
     {

--- a/Source/Fang/Fang_Matrix.c
+++ b/Source/Fang/Fang_Matrix.c
@@ -61,9 +61,9 @@ Fang_Mat3x3Multv(
     const Fang_Vec3   b)
 {
     return (Fang_Vec3){
-        a.m00 * b.x + a.m01 * b.y + a.m02 * b.z,
-        a.m10 * b.x + a.m11 * b.y + a.m12 * b.z,
-        a.m20 * b.x + a.m21 * b.y + a.m22 * b.z,
+        .x = a.m00 * b.x + a.m01 * b.y + a.m02 * b.z,
+        .y = a.m10 * b.x + a.m11 * b.y + a.m12 * b.z,
+        .z = a.m20 * b.x + a.m21 * b.y + a.m22 * b.z,
     };
 }
 

--- a/Source/Fang/Fang_Ray.c
+++ b/Source/Fang/Fang_Ray.c
@@ -54,7 +54,10 @@ Fang_RayCast(
 
     const Fang_Vec3 * const dir = &camera->dir;
     const Fang_Vec3 * const cam = &camera->cam;
-    const Fang_Vec2         pos = (Fang_Vec2){camera->pos.x, camera->pos.y};
+    const Fang_Vec2         pos = (Fang_Vec2){
+        .x = camera->pos.x,
+        .y = camera->pos.y
+    };
 
     memset(rays, 0, sizeof(Fang_Ray) * count);
 

--- a/Source/Fang/Fang_Ray.c
+++ b/Source/Fang/Fang_Ray.c
@@ -42,13 +42,13 @@ typedef struct Fang_Ray {
 
 static inline void
 Fang_RayCast(
-    const Fang_Map    * const map,
     const Fang_Camera * const camera,
+    const Fang_Map    * const map,
           Fang_Ray    * const rays,
     const size_t              count)
 {
-    assert(map);
     assert(camera);
+    assert(map);
     assert(rays);
     assert(count);
 

--- a/Source/Fang/Fang_Ray.c
+++ b/Source/Fang/Fang_Ray.c
@@ -125,13 +125,13 @@ Fang_RayCast(
 
             if (side_dist.x < side_dist.y)
             {
-                int_pos.x  += step_dist.x;
+                int_pos.x    += step_dist.x;
                 side_dist.x  += delta_dist.x;
                 hit->norm_dir = side_face_x;
             }
             else if (side_dist.x > side_dist.y)
             {
-                int_pos.y  += step_dist.y;
+                int_pos.y    += step_dist.y;
                 side_dist.y  += delta_dist.y;
                 hit->norm_dir = side_face_y;
             }
@@ -139,13 +139,13 @@ Fang_RayCast(
             {
                 if (step_dist.x < step_dist.y)
                 {
-                    int_pos.x  += step_dist.x;
+                    int_pos.x    += step_dist.x;
                     side_dist.x  += delta_dist.x;
                     hit->norm_dir = side_face_x;
                 }
                 else
                 {
-                    int_pos.y  += step_dist.y;
+                    int_pos.y    += step_dist.y;
                     side_dist.y  += delta_dist.y;
                     hit->norm_dir = side_face_y;
                 }

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -410,7 +410,7 @@ Fang_DrawMapFloor(
 
     const Fang_Rect viewport = Fang_FramebufferGetViewport(framebuf);
 
-    if (camera->pos.z <= viewport.h / -2.0f)
+    if (camera->pos.z <= 0.0f)
         return;
 
     /* Calculate vertical offset in screen space */

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -394,7 +394,6 @@ Fang_DrawMapFloor(
     assert(framebuf);
     assert(camera);
     assert(map);
-    assert(texture);
 
     const Fang_Rect viewport = Fang_FramebufferGetViewport(framebuf);
 
@@ -418,6 +417,9 @@ Fang_DrawMapFloor(
         .x = camera->dir.x - camera->cam.x,
         .y = camera->dir.y - camera->cam.y,
     };
+
+    const int texture_width  = (texture) ? texture->width  : 32;
+    const int texture_height = (texture) ? texture->height : 32;
 
     for (int y = viewport.h / 2 + offset; y < viewport.h; ++y)
     {
@@ -449,15 +451,15 @@ Fang_DrawMapFloor(
         {
             Fang_Point tex_pos = {
                 .x = (int)roundf(
-                    texture->width * (floor_pos.x - (int)floor_pos.x)
+                    texture_width * (floor_pos.x - (int)floor_pos.x)
                 ),
                 .y = (int)roundf(
-                    texture->height * (floor_pos.y - (int)floor_pos.y)
+                    texture_height * (floor_pos.y - (int)floor_pos.y)
                 ),
             };
 
-            tex_pos.x &= (texture->width  - 1);
-            tex_pos.y &= (texture->height - 1);
+            tex_pos.x &= (texture_width  - 1);
+            tex_pos.y &= (texture_height - 1);
 
             floor_pos.x += floor_step.x;
             floor_pos.y += floor_step.y;

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -870,14 +870,14 @@ Fang_DrawMinimap(
         }
     }
 
-    const Fang_Point camera_pos = {
+    const Fang_Point minimap_pos = {
         .x = (int)((camera->pos.x / map->size) * bounds.w),
         .y = (int)((camera->pos.y / map->size) * bounds.h),
     };
 
 
-    if ((camera_pos.x >= 0 || camera_pos.x < bounds.w)
-    ||  (camera_pos.y >= 0 || camera_pos.y < bounds.h))
+    if ((minimap_pos.x >= 0 && minimap_pos.x < bounds.w)
+    &&  (minimap_pos.y >= 0 && minimap_pos.y < bounds.h))
     {
         for (size_t i = 0; i < count; ++i)
         {
@@ -890,12 +890,15 @@ Fang_DrawMinimap(
 
             Fang_DrawLine(
                 framebuf,
-                &camera_pos,
+                &minimap_pos,
                 &(Fang_Point){
                     .x = (int)((ray_pos.x / map->size) * bounds.w),
                     .y = (int)((ray_pos.y / map->size) * bounds.h),
                 },
-                &FANG_BLUE
+                &(Fang_Color){
+                    .b = 255,
+                    .a = 1,
+                }
             );
         }
     }
@@ -903,8 +906,8 @@ Fang_DrawMinimap(
     Fang_FillRect(
         framebuf,
         &(Fang_Rect){
-            .x = clamp(camera_pos.x, 0, bounds.w)  - 5,
-            .y = clamp(camera_pos.y, 0, bounds.h) - 5,
+            .x = clamp(minimap_pos.x, 0, bounds.w) - 5,
+            .y = clamp(minimap_pos.y, 0, bounds.h) - 5,
             .w = 10,
             .h = 10,
         },

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -114,22 +114,29 @@ Fang_DrawRect(
     assert(rect);
     assert(color);
 
-    for (int h = 0; h < rect->h; h += rect->h - 1)
+    const Fang_Rect viewport  = Fang_FramebufferGetViewport(framebuf);
+    const Fang_Rect dest_rect = Fang_RectClip(rect, &viewport);
+
+    for (int h = 0; h < dest_rect.h; h += dest_rect.h - 1)
     {
-        for (int w = 0; w < rect->w; ++w)
+        for (int w = 0; w < dest_rect.w; ++w)
         {
             Fang_FramebufferPutPixel(
-                framebuf, &(Fang_Point){rect->x + w, rect->y + h}, color
+                framebuf,
+                &(Fang_Point){dest_rect.x + w, dest_rect.y + h},
+                color
             );
         }
     }
 
-    for (int h = 0; h < rect->h; ++h)
+    for (int h = 0; h < dest_rect.h; ++h)
     {
-        for (int w = 0; w < rect->w; w += rect->w - 1)
+        for (int w = 0; w < dest_rect.w; w += dest_rect.w - 1)
         {
             Fang_FramebufferPutPixel(
-                framebuf, &(Fang_Point){rect->x + w, rect->y + h}, color
+                framebuf,
+                &(Fang_Point){dest_rect.x + w, dest_rect.y + h},
+                color
             );
         }
     }
@@ -150,12 +157,17 @@ Fang_FillRect(
     assert(rect);
     assert(color);
 
-    for (int h = 0; h < rect->h; ++h)
+    const Fang_Rect viewport  = Fang_FramebufferGetViewport(framebuf);
+    const Fang_Rect dest_rect = Fang_RectClip(rect, &viewport);
+
+    for (int h = 0; h < dest_rect.h; ++h)
     {
-        for (int w = 0; w < rect->w; ++w)
+        for (int w = 0; w < dest_rect.w; ++w)
         {
             Fang_FramebufferPutPixel(
-                framebuf, &(Fang_Point){rect->x + w, rect->y + h}, color
+                framebuf,
+                &(Fang_Point){dest_rect.x + w, dest_rect.y + h},
+                color
             );
         }
     }
@@ -200,25 +212,18 @@ Fang_DrawImageEx(
         ? Fang_RectClip(source, &image_area)
         : image_area;
 
-    const Fang_Rect framebuf_area = {
-        .w = framebuf->color.width,
-        .h = framebuf->color.height,
-    };
+    const Fang_Rect framebuf_area = Fang_FramebufferGetViewport(framebuf);
 
     const Fang_Rect dest_area = (dest)
         ? *dest
         : framebuf_area;
 
-    for (int x = dest_area.x; x < dest_area.x + dest_area.w; ++x)
+    const Fang_Rect clipped_area = Fang_RectClip(&dest_area, &framebuf_area);
+
+    for (int x = clipped_area.x; x < clipped_area.x + clipped_area.w; ++x)
     {
-        if (x < 0 || x >= framebuf->color.width)
-            continue;
-
-        for (int y = dest_area.y; y < dest_area.y + dest_area.h; ++y)
+        for (int y = clipped_area.y; y < clipped_area.y + clipped_area.h; ++y)
         {
-            if (y < 0 || y >= framebuf->color.height)
-                continue;
-
             float r_x = (float)(x - dest_area.x) / (float)dest_area.w;
             float r_y = (float)(y - dest_area.y) / (float)dest_area.h;
 

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -336,11 +336,11 @@ static void
 Fang_DrawMapSkybox(
           Fang_Framebuffer * const framebuf,
     const Fang_Camera      * const camera,
-    const Fang_Image       * const skybox)
+    const Fang_Image       * const texture)
 {
     assert(framebuf);
     assert(camera);
-    assert(skybox);
+    assert(texture);
 
     const Fang_Rect viewport = Fang_FramebufferGetViewport(framebuf);
 
@@ -364,7 +364,7 @@ Fang_DrawMapSkybox(
     {
         Fang_DrawImageEx(
             framebuf,
-            skybox,
+            texture,
             NULL,
             &(Fang_Rect){
                 .x = dest.x + (dest.w * i),
@@ -377,7 +377,7 @@ Fang_DrawMapSkybox(
         );
     }
 
-    Fang_DrawImage(framebuf, skybox, NULL, &dest);
+    Fang_DrawImage(framebuf, texture, NULL, &dest);
 }
 
 /**
@@ -389,12 +389,12 @@ Fang_DrawMapFloor(
           Fang_Framebuffer * const framebuf,
     const Fang_Camera      * const camera,
     const Fang_Map         * const map,
-    const Fang_Image       * const floor)
+    const Fang_Image       * const texture)
 {
     assert(framebuf);
     assert(camera);
     assert(map);
-    assert(floor);
+    assert(texture);
 
     const Fang_Rect viewport = Fang_FramebufferGetViewport(framebuf);
 
@@ -449,20 +449,20 @@ Fang_DrawMapFloor(
         {
             Fang_Point tex_pos = {
                 .x = (int)roundf(
-                    floor->width * (floor_pos.x - (int)floor_pos.x)
+                    texture->width * (floor_pos.x - (int)floor_pos.x)
                 ),
                 .y = (int)roundf(
-                    floor->height * (floor_pos.y - (int)floor_pos.y)
+                    texture->height * (floor_pos.y - (int)floor_pos.y)
                 ),
             };
 
-            tex_pos.x &= (floor->width  - 1);
-            tex_pos.y &= (floor->height - 1);
+            tex_pos.x &= (texture->width  - 1);
+            tex_pos.y &= (texture->height - 1);
 
             floor_pos.x += floor_step.x;
             floor_pos.y += floor_step.y;
 
-            Fang_Color dest_color = Fang_ImageQuery(floor, &tex_pos);
+            Fang_Color dest_color = Fang_ImageQuery(texture, &tex_pos);
 
             /* Shortening the floor fog seems to align closer to tile fog */
             if (map->fog_distance != 0.0f)

--- a/Source/Fang/Fang_State.c
+++ b/Source/Fang/Fang_State.c
@@ -13,16 +13,18 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-typedef enum Fang_TileType {
-    FANG_TILETYPE_NONE,
-    FANG_TILETYPE_SOLID,
-    FANG_TILETYPE_FLOATING,
+typedef struct Fang_Clock {
+    uint32_t time;
+    uint32_t accumulator;
+} Fang_Clock;
 
-    FANG_NUM_TILETYPE,
-} Fang_TileType;
-
-typedef struct Fang_Tile {
-    Fang_Texture texture;
-    float y;
-    float h;
-} Fang_Tile;
+typedef struct Fang_State {
+    Fang_Map       map;
+    Fang_Atlas     textures;
+    Fang_Ray       raycast[FANG_WINDOW_SIZE];
+    Fang_Clock     clock;
+    Fang_Camera    camera;
+    Fang_Entity    player;
+    Fang_Interface interface;
+    Fang_Entity    entities[FANG_MAX_ENTITIES];
+} Fang_State;

--- a/Source/Fang/Fang_Textures.c
+++ b/Source/Fang/Fang_Textures.c
@@ -44,6 +44,7 @@ typedef enum Fang_Texture {
     FANG_TEXTURE_FORMULA,
 
     FANG_NUM_TEXTURES,
+    FANG_TEXTURE_NONE,
 } Fang_Texture;
 
 /**
@@ -167,7 +168,10 @@ Fang_AtlasQuery(
     const Fang_Texture         id)
 {
     assert(atlas);
-    assert(id < FANG_NUM_TEXTURES);
 
+    if (id == FANG_TEXTURE_NONE)
+        return NULL;
+
+    assert(id < FANG_NUM_TEXTURES);
     return &atlas->textures[id];
 }

--- a/Source/Fang/Fang_Textures.c
+++ b/Source/Fang/Fang_Textures.c
@@ -88,7 +88,7 @@ Fang_AtlasLoad(
 
     Fang_Image * const result = &atlas->textures[id];
 
-    if (result->pixels)
+    if (Fang_ImageValid(result))
         Fang_AtlasUnload(atlas, id);
 
     typedef enum {
@@ -125,7 +125,7 @@ Fang_AtlasLoad(
     };
 
     *result = Fang_TGALoad(texture_info[id].path);
-    if (!result->pixels)
+    if (!Fang_ImageValid(result))
         return 1;
 
     switch (texture_info[id].type)

--- a/Source/Fang/Fang_Vector.c
+++ b/Source/Fang/Fang_Vector.c
@@ -13,12 +13,18 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-typedef struct Fang_Vec2 {
-    float x, y;
+typedef union Fang_Vec2 {
+    struct {
+        float x, y;
+    };
+    float xy[2];
 } Fang_Vec2;
 
-typedef struct Fang_Vec3 {
-    float x, y, z;
+typedef union Fang_Vec3 {
+    struct {
+        float x, y, z;
+    };
+    float xyz[3];
 } Fang_Vec3;
 
 static inline Fang_Vec2
@@ -26,7 +32,7 @@ Fang_Vec2Divf(
     const Fang_Vec2 a,
     const float     b)
 {
-    return (Fang_Vec2){a.x / b, a.y / b};
+    return (Fang_Vec2){.x = a.x / b, .y = a.y / b};
 }
 
 static inline Fang_Vec2
@@ -34,7 +40,7 @@ Fang_Vec2Multf(
     const Fang_Vec2 a,
     const float     b)
 {
-    return (Fang_Vec2){a.x * b, a.y * b};
+    return (Fang_Vec2){.x = a.x * b, .y = a.y * b};
 }
 
 static inline float

--- a/Source/Platform/FangSDL.c
+++ b/Source/Platform/FangSDL.c
@@ -136,8 +136,7 @@ int Fang_Main(int argc, char** argv)
     Fang_Input input;
     SDL_memset(&input, 0, sizeof(Fang_Input));
 
-    if (Fang_Init() != 0)
-        goto Error_GameInit;
+    Fang_Init();
 
     bool quit = false;
     while (!quit)
@@ -362,7 +361,7 @@ int Fang_Main(int argc, char** argv)
             if (error)
                 break;
 
-            Fang_Update(&input, &framebuf);
+            Fang_Update(&input, &framebuf, SDL_GetTicks());
 
             SDL_UnlockTexture(depth);
             SDL_UnlockTexture(texture);
@@ -375,7 +374,6 @@ int Fang_Main(int argc, char** argv)
 
     FangSDL_DisconnectController(&controller);
 
-Error_GameInit:
     Fang_Quit();
 
 Error_Depthbuffer:

--- a/Source/Platform/FangSDL.c
+++ b/Source/Platform/FangSDL.c
@@ -131,6 +131,8 @@ int Fang_Main(int argc, char** argv)
     SDL_JoystickEventState(SDL_ENABLE);
     SDL_GameControllerEventState(SDL_ENABLE);
 
+    SDL_SetRelativeMouseMode(1);
+
     SDL_RaiseWindow(window);
 
     Fang_Input input;


### PR DESCRIPTION
Resolves #20 
Resolves #18 

## Description

Adding in physics and player control.

With everything being static variables this was getting a bit messy, so the relevant game state
data has been moved into a `Fang_State` game state struct.

## Changes
- Add `Fang_State` game state struct, and move currently-static variables into it
- Add clock variables for keeping track of time delta
- Remove `Fang_LoadMap()` / `Fang_DestroyMap()`, these will later be the actual functions for loading a map from a file
- Allow passing `NULL` to `Fang_ImageQuery()` (will display the "missing" texture)
- Remove texture atlas and `Fang_TileType*` from `Fang_Map`
- Change textures on `Fang_Map` from the actual images to the `Fang_Texture` identifiers instead
- Update the order of parameters in the render functions to be more consistent
- Handles missing textures for floor/skybox (draws XOR texture for missing floor, and a rectangle with the map fog color for missing skybox)
- Adds `Fang_ImageValid()` to consolidate image validity checks and assertions
- Fixes mouse not being reset in `Fang_InputReset()`
- Fixes incorrect camera rotation calculation
- Update vector structs to unions to allow for accessing `.x, .y, .z` or `.xyz[#]`
- Adds player physics constants
- Adds player control including jumping (only when on surfaces)
- Fixes incorrect threshold in `Fang_DrawMapFloor()`
- Add clipping to image/rect rendering functions 
- Adds tile collisions with player in X/Y axis (walking into walls)
- Adds tile collisions with player in Z axis (jumping into floating walls, jumping onto walls, automatically stepping onto short walls)
