### PR TITLE
Prevent Hot UI If There Is Already An Active Item

### DIFF
--- a/Source/Fang/Fang_Interface.c
+++ b/Source/Fang/Fang_Interface.c
@@ -82,7 +82,10 @@ Fang_InterfaceUpdate(
     Fang_Interface * const interface)
 {
     assert(interface);
-    interface->hot = interface->next;
+
+    if (!interface->active)
+        interface->hot = interface->next;
+
     interface->id   = 0;
     interface->next = 0;
 }
@@ -236,14 +239,14 @@ Fang_InterfaceSlider(
 
         const bool active = interface->active == id;
         const bool hot    = interface->hot    == id;
-        const bool next   = interface->next   == id;
 
         Fang_Color color;
+
         if (active)
             color = interface->theme.colors.foreground;
         else if (hot)
             color = interface->theme.colors.highlight;
-        else if (!next)
+        else
             color = interface->theme.colors.disabled;
 
         Fang_DrawRect(framebuf, bounds, &color);


### PR DESCRIPTION
Resolves #44 

## Description

There were two problems essentially:
- `Fang_InterfaceUpdate()` was setting the hot item regardless of if there was an active item
- Sliders had an incorrect conditional leading them to use incorrect colors. This is specifically when they were moused over while another element was the active item

