### PR TITLE
Cull Entities & Tiles By Distance

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -241,6 +241,7 @@ Fang_Update(
     Fang_DrawEntities(
         framebuf,
         &gamestate.camera,
+        &gamestate.map,
         gamestate.entities,
         FANG_MAX_ENTITIES
     );

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -79,3 +79,43 @@ Fang_MapQuery(
             return NULL;
     }
 }
+
+static inline Fang_Color
+Fang_MapGetFog(
+    const Fang_Map   * const map,
+    const float              dist)
+{
+    assert(map);
+
+    if (map->fog_distance != 0.0f)
+    {
+        return (Fang_Color){
+            .r = map->fog.r,
+            .g = map->fog.g,
+            .b = map->fog.b,
+            .a = (uint8_t)(
+                clamp(dist / map->fog_distance, 0.0f, 1.0f) * 255.0f
+            ),
+        };
+    }
+
+    return (Fang_Color){0, 0, 0, 0};
+}
+
+static inline Fang_Color
+Fang_MapBlendFog(
+    const Fang_Map   * const map,
+    const Fang_Color * const color,
+    const float              dist)
+{
+    assert(map);
+    assert(color);
+
+    if (map->fog_distance != 0.0f)
+    {
+        const Fang_Color fog = Fang_MapGetFog(map, dist);
+        return Fang_ColorBlend(&fog, color);
+    }
+
+    return *color;
+}

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -534,6 +534,9 @@ Fang_DrawMapTiles(
             if (hit->front_dist <= 0.0f)
                 continue;
 
+            if (hit->front_dist > map->fog_distance)
+                continue;
+
             const Fang_Image * const wall_tex = Fang_AtlasQuery(
                 textures, hit->tile->texture
             );


### PR DESCRIPTION
Resolves #46 

## Description

Updates the renderer to avoid drawing entities or tiles that cannot be seen.

## Changes
- Add entity fog blending
- Cull entities that are further than the fog distance
- Cull tiles that are further than the fog distance
- Move fog calculation logic into its own functions

