### PR TITLE
Add Support For Entity Textures

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -87,13 +87,15 @@ Fang_Init(void)
     {
         Fang_Entity entities [FANG_MAX_ENTITIES] = {
             [0] = (Fang_Entity){
-                (Fang_Body){
+                .texture = FANG_TEXTURE_NONE,
+                .body = (Fang_Body){
                     .pos  = (Fang_Vec3){.x = 2.0f, .y = 2.0f},
                     .size = 1,
                 },
             },
             [1] = (Fang_Entity){
-                (Fang_Body){
+                .texture = FANG_TEXTURE_NONE,
+                .body = (Fang_Body){
                     .pos  = (Fang_Vec3){.x = 6.0f, .y = 5.5f},
                     .size = 1,
                 },
@@ -241,6 +243,7 @@ Fang_Update(
     Fang_DrawEntities(
         framebuf,
         &gamestate.camera,
+        &gamestate.textures,
         &gamestate.map,
         gamestate.entities,
         FANG_MAX_ENTITIES

--- a/Source/Fang/Fang_Entity.c
+++ b/Source/Fang/Fang_Entity.c
@@ -18,5 +18,6 @@ enum {
 };
 
 typedef struct Fang_Entity {
-    Fang_Body body;
+    Fang_Body    body;
+    Fang_Texture texture;
 } Fang_Entity;

--- a/Source/Fang/Fang_Textures.c
+++ b/Source/Fang/Fang_Textures.c
@@ -14,10 +14,10 @@
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * A constant representing the width|height of a face in a tile-type texture.
+ * A constant representing the width|height of a texture frame.
 **/
 enum {
-    FANG_FACE_SIZE = 128,
+    FANG_TEXTURE_SIZE = 128,
 };
 
 /**
@@ -131,8 +131,8 @@ Fang_AtlasLoad(
     switch (texture_info[id].type)
     {
         case TILE_TEXTURE:
-            assert(result->width  == FANG_FACE_SIZE * 6);
-            assert(result->height == FANG_FACE_SIZE);
+            assert(result->width  == FANG_TEXTURE_SIZE * 6);
+            assert(result->height == FANG_TEXTURE_SIZE);
             break;
 
         case FONT_TEXTURE:


### PR DESCRIPTION
Resolves #49 

## Description

Adds support for drawing entities using a texture. 
No entity-specific textures included in resources yet.

## Changes
- Add `Fang_Entity.texture` identifier
- Update `Fang_DrawImageEx()` to take a "shade": a color to blend with the image while drawing
- Update `FANG_FACE_SIZE` to `FANG_TEXTURE_SIZE`

