### PR TITLE
Avoid Division By Zero In Fang_FramebufferShadeDepth()

### DIFF
--- a/Source/Fang/Fang_Framebuffer.c
+++ b/Source/Fang/Fang_Framebuffer.c
@@ -128,6 +128,9 @@ Fang_FramebufferShadeDepth(
     assert(framebuf->color.stride == 4);
     assert(color);
 
+    if (dist == 0.0f)
+        return;
+
     for (int x = 0; x < framebuf->color.width; ++x)
     {
         for (int y = 0; y < framebuf->color.height; ++y)


### PR DESCRIPTION
Resolves #61 

## Description



## Changes
- Avoids depth shading when distance is zero

