### PR TITLE
Render Tops Of Tiles When Standing On Them

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -39,6 +39,7 @@
 #include "Fang_Map.c"
 #include "Fang_Body.c"
 #include "Fang_Camera.c"
+#include "Fang_DDA.c"
 #include "Fang_Ray.c"
 #include "Fang_Entity.c"
 #include "Fang_Render.c"

--- a/Source/Fang/Fang_DDA.c
+++ b/Source/Fang/Fang_DDA.c
@@ -1,0 +1,156 @@
+// Copyright (C) 2021  Antonio Lassandro
+
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+typedef enum Fang_Face {
+    FANG_FACE_NORTH  = 0,
+    FANG_FACE_SOUTH  = 1,
+    FANG_FACE_EAST   = 2,
+    FANG_FACE_WEST   = 3,
+    FANG_FACE_TOP    = 4,
+    FANG_FACE_BOTTOM = 5,
+} Fang_Face;
+
+/**
+ * A structure containing the necessary data for the Digital Differential
+ * Analyzer.
+**/
+typedef struct Fang_DDAState {
+    Fang_Vec2 start; /* Starting position of the DDA                      */
+    Fang_Vec2 dir;   /* Starting direction vector of the DDA              */
+    Fang_Vec2 pos;   /* Current integer position (tile) of the DDA        */
+    Fang_Vec2 delta; /* Distance it takes (X/Y) to step over a tile       */
+    Fang_Vec2 step;  /* Direction (X/Y) to step when moving the position  */
+    Fang_Vec2 side;  /* Distance from the start position to the next tile */
+    Fang_Face face;  /* Face direction at the current position            */
+} Fang_DDAState;
+
+/**
+ * Initializes the DDA based on a given starting position and direction vector.
+**/
+static inline void
+Fang_DDAInit(
+          Fang_DDAState * const dda,
+    const Fang_Vec2     * const start,
+    const Fang_Vec2     * const dir)
+{
+    assert(dda);
+    assert(start);
+    assert(dir);
+
+    dda->start = *start;
+    dda->dir   = *dir;
+
+    dda->pos = (Fang_Vec2){
+        .x = floorf(start->x),
+        .y = floorf(start->y),
+    };
+
+    dda->delta = (Fang_Vec2){
+        .x = (dir->y == 0.0f)
+            ? 0.0f
+            : (dir->x == 0.0f) ? 0.0f : fabsf(1.0f / dir->x),
+        .y = (dir->x == 0.0f)
+            ? 0.0f
+            : (dir->y == 0.0f) ? 0.0f : fabsf(1.0f / dir->y),
+    };
+
+    if (dir->x < 0.0f)
+    {
+        dda->step.x = -1.0f;
+        dda->side.x = (start->x - dda->pos.x) * dda->delta.x;
+    }
+    else
+    {
+        dda->step.x = 1.0f;
+        dda->side.x = (dda->pos.x + 1.0f - start->x) * dda->delta.x;
+    }
+
+    if (dir->y < 0.0f)
+    {
+        dda->step.y = -1.0f;
+        dda->side.y = (start->y - dda->pos.y) * dda->delta.y;
+    }
+    else
+    {
+        dda->step.y = 1.0f;
+        dda->side.y = (dda->pos.y + 1.0f - start->y) * dda->delta.y;
+    }
+}
+
+/**
+ * Increments the DDA by one step, returning the distance from the starting
+ * position to the current point.
+**/
+static float
+Fang_DDAStep(
+    Fang_DDAState * const dda)
+{
+    assert(dda);
+
+    const Fang_Face x_face = (dda->step.x < 0.0f)
+        ? FANG_FACE_EAST
+        : FANG_FACE_WEST;
+
+    const Fang_Face y_face = (dda->step.y < 0.0f)
+        ? FANG_FACE_SOUTH
+        : FANG_FACE_NORTH;
+
+    if (dda->side.x < dda->side.y)
+    {
+        dda->pos.x  += dda->step.x;
+        dda->side.x += dda->delta.x;
+        dda->face    = x_face;
+    }
+    else if (dda->side.x > dda->side.y)
+    {
+        dda->pos.y  += dda->step.y;
+        dda->side.y += dda->delta.y;
+        dda->face    = y_face;
+    }
+    else /* 0 case */
+    {
+        if (dda->step.x < dda->step.y)
+        {
+            dda->pos.x  += dda->step.x;
+            dda->side.x += dda->delta.x;
+            dda->face    = x_face;
+        }
+        else if (dda->step.x > dda->step.y)
+        {
+            dda->pos.y  += dda->step.y;
+            dda->side.y += dda->delta.y;
+            dda->face    = y_face;
+        }
+    }
+
+    float result;
+
+    if (dda->face == x_face)
+    {
+        result = dda->pos.x - dda->start.x + (1.0f - dda->step.x) / 2.0f;
+
+        if (dda->dir.x != 0.0f)
+            result /= dda->dir.x;
+    }
+    else
+    {
+        result = dda->pos.y - dda->start.y + (1.0f - dda->step.y) / 2.0f;
+
+        if (dda->dir.y != 0.0f)
+            result /= dda->dir.y;
+    }
+
+    return result;
+}

--- a/Source/Fang/Fang_Ray.c
+++ b/Source/Fang/Fang_Ray.c
@@ -180,7 +180,7 @@ Fang_RayCast(
                     .y = pos.y + (hit->front_dist * cam_ray.y),
                 };
 
-                const Fang_Vec2 old_trunc_pos = int_pos;
+                const Fang_Vec2 old_int_pos = int_pos;
                 const Fang_Vec2 old_side_dist = side_dist;
 
                 /* Run an additional increment to calculate the back face hit */
@@ -241,7 +241,7 @@ Fang_RayCast(
                     };
                 }
 
-                int_pos = old_trunc_pos;
+                int_pos   = old_int_pos;
                 side_dist = old_side_dist;
 
                 hit_count++;

--- a/Source/Fang/Fang_Ray.c
+++ b/Source/Fang/Fang_Ray.c
@@ -17,15 +17,6 @@ enum {
     FANG_RAY_MAX_STEPS = 64,
 };
 
-typedef enum Fang_Face {
-    FANG_FACE_NORTH  = 0,
-    FANG_FACE_SOUTH  = 1,
-    FANG_FACE_EAST   = 2,
-    FANG_FACE_WEST   = 3,
-    FANG_FACE_TOP    = 4,
-    FANG_FACE_BOTTOM = 5,
-} Fang_Face;
-
 typedef struct Fang_RayHit {
     const Fang_Tile * tile;
     Fang_Vec2  front_hit;
@@ -72,50 +63,8 @@ Fang_RayCast(
             .y = dir->y + cam->y * ray_cam,
         };
 
-        const Fang_Vec2 delta_dist = {
-            .x = (cam_ray.y == 0.0f)
-                ? 0.0f
-                : cam_ray.x == 0.0f ? 0.0f : fabsf(1.0f / cam_ray.x),
-            .y = (cam_ray.x == 0.0f)
-                ? 0.0f
-                : (cam_ray.y == 0.0f) ? 0.0f : fabsf(1.0f / cam_ray.y),
-        };
-
-        Fang_Vec2 int_pos = {
-            .x = floorf(pos.x),
-            .y = floorf(pos.y),
-        };
-
-        Fang_Vec2 step_dist;
-        Fang_Vec2 side_dist;
-        Fang_Face side_face_x;
-        Fang_Face side_face_y;
-
-        if (cam_ray.x < 0.0f)
-        {
-            step_dist.x = -1.0f;
-            side_dist.x = (pos.x - int_pos.x) * delta_dist.x;
-            side_face_x  = FANG_FACE_EAST;
-        }
-        else
-        {
-            step_dist.x = 1.0f;
-            side_dist.x = (int_pos.x + 1.0f - pos.x) * delta_dist.x;
-            side_face_x  = FANG_FACE_WEST;
-        }
-
-        if (cam_ray.y < 0.0f)
-        {
-            step_dist.y = -1.0f;
-            side_dist.y = (pos.y - int_pos.y) * delta_dist.y;
-            side_face_y  = FANG_FACE_SOUTH;
-        }
-        else
-        {
-            step_dist.y = 1.0f;
-            side_dist.y = (int_pos.y + 1.0f - pos.y) * delta_dist.y;
-            side_face_y  = FANG_FACE_NORTH;
-        }
+        Fang_DDAState dda;
+        Fang_DDAInit(&dda, &pos, &cam_ray);
 
         size_t hit_count = 0;
 
@@ -123,127 +72,27 @@ Fang_RayCast(
         {
             Fang_RayHit * const hit = &rays[i].hits[hit_count];
 
-            if (side_dist.x < side_dist.y)
-            {
-                int_pos.x    += step_dist.x;
-                side_dist.x  += delta_dist.x;
-                hit->norm_dir = side_face_x;
-            }
-            else if (side_dist.x > side_dist.y)
-            {
-                int_pos.y    += step_dist.y;
-                side_dist.y  += delta_dist.y;
-                hit->norm_dir = side_face_y;
-            }
-            else /* 0 case */
-            {
-                if (step_dist.x < step_dist.y)
-                {
-                    int_pos.x    += step_dist.x;
-                    side_dist.x  += delta_dist.x;
-                    hit->norm_dir = side_face_x;
-                }
-                else
-                {
-                    int_pos.y    += step_dist.y;
-                    side_dist.y  += delta_dist.y;
-                    hit->norm_dir = side_face_y;
-                }
-            }
+            hit->front_dist = Fang_DDAStep(&dda);
 
-            hit->tile = Fang_MapQuery(map, (int)int_pos.x, (int)int_pos.y);
+            hit->tile = Fang_MapQuery(map, (int)dda.pos.x, (int)dda.pos.y);
 
             if (hit->tile)
             {
-                /* Check the axis of collision */
-                if (hit->norm_dir == side_face_x)
-                {
-                    hit->front_dist = (
-                        int_pos.x - pos.x + (1.0f - step_dist.x) / 2.0f
-                    );
+                const Fang_DDAState old_dda = dda;
 
-                    if (cam_ray.x != 0.0f)
-                        hit->front_dist /= cam_ray.x;
-                }
-                else if (hit->norm_dir == side_face_y)
-                {
-                    hit->front_dist = (
-                        int_pos.y - pos.y + (1.0f - step_dist.y) / 2.0f
-                    );
-
-                    if (cam_ray.y != 0.0f)
-                        hit->front_dist /= cam_ray.y;
-                }
-
+                hit->norm_dir  = dda.face;
                 hit->front_hit = (Fang_Vec2){
                     .x = pos.x + (hit->front_dist * cam_ray.x),
                     .y = pos.y + (hit->front_dist * cam_ray.y),
                 };
 
-                const Fang_Vec2 old_int_pos = int_pos;
-                const Fang_Vec2 old_side_dist = side_dist;
+                hit->back_dist = Fang_DDAStep(&dda);
+                hit->back_hit  = (Fang_Vec2){
+                    .x = pos.x + (hit->back_dist * cam_ray.x),
+                    .y = pos.y + (hit->back_dist * cam_ray.y),
+                };
 
-                /* Run an additional increment to calculate the back face hit */
-                {
-                    Fang_Face face = hit->norm_dir;
-
-                    if (side_dist.x < side_dist.y)
-                    {
-                        int_pos.x += step_dist.x;
-                        side_dist.x += delta_dist.x;
-                        face = side_face_x;
-                    }
-                    else if (side_dist.x > side_dist.y)
-                    {
-                        int_pos.y += step_dist.y;
-                        side_dist.y += delta_dist.y;
-                        face = side_face_y;
-                    }
-                    else /* 0 case */
-                    {
-                        if (step_dist.x < step_dist.y)
-                        {
-                            int_pos.x += step_dist.x;
-                            side_dist.x += delta_dist.x;
-                            face = side_face_x;
-                        }
-                        else
-                        {
-                            int_pos.y += step_dist.y;
-                            side_dist.y += delta_dist.y;
-                            face = side_face_y;
-                        }
-                    }
-
-                    /* Check the axis of collision */
-                    if (face == side_face_x)
-                    {
-                        hit->back_dist = (
-                            int_pos.x - pos.x + (1.0f - step_dist.x) / 2.0f
-                        );
-
-                        if (cam_ray.x != 0.0f)
-                            hit->back_dist /= cam_ray.x;
-                    }
-                    else if (face == side_face_y)
-                    {
-                        hit->back_dist = (
-                            int_pos.y - pos.y + (1.0f - step_dist.y) / 2.0f
-                        );
-
-                        if (cam_ray.y != 0.0f)
-                            hit->back_dist /= cam_ray.y;
-                    }
-
-                    hit->back_hit = (Fang_Vec2){
-                        .x = pos.x + (hit->back_dist * cam_ray.x),
-                        .y = pos.y + (hit->back_dist * cam_ray.y),
-                    };
-                }
-
-                int_pos   = old_int_pos;
-                side_dist = old_side_dist;
-
+                dda = old_dda;
                 hit_count++;
             }
         }

--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -526,9 +526,6 @@ Fang_DrawMapTiles(
             if (!hit->tile)
                 continue;
 
-            if (hit->front_dist <= 0.0f)
-                continue;
-
             if (hit->front_dist > map->fog_distance)
                 continue;
 
@@ -552,6 +549,13 @@ Fang_DrawMapTiles(
 
                 dest_rect.x = (int)i;
                 dest_rect.w = 1;
+
+                /* Player is standing on a tile, front-face is behind them */
+                if (face_dist <= 0.0f)
+                {
+                    dest_rect.y = viewport.h;
+                    dest_rect.h = 0;
+                }
 
                 if (k == 0)
                     front_face = dest_rect;


### PR DESCRIPTION
## Description

This corrects the issue where the tops of tiles were not being drawn if you were standing on them.

For bottoms of tiles that are above the player, the camera isn't able to look "up" enough to actually see them anyway.

## Changes
- Move DDA algorithm logic out to its own functions
- Add an additional raycast hit if the player is standing on the top of a tile
- Remove `<= 0.0f` face distance culling when rendering tiles, and instead change destination rectangle to draw to bottom of screen

