### PR TITLE
Handle NULL File Handle When File Isn't Found

### DIFF
--- a/Source/Platform/FangSDL_File.c
+++ b/Source/Platform/FangSDL_File.c
@@ -94,7 +94,9 @@ Error_CantRead:
     goto Error;
 
 Error:
-    SDL_RWclose(file);
+    if (file)
+        SDL_RWclose(file);
+
     SDL_free(full_path);
     SDL_free(result->data);
 


### PR DESCRIPTION
## Description

Apparently a `NULL` file handle wasn't accounted for in the file loading, probably because so far testing has been done with "none" type textures but never missing texture files

## Changes
- Only close the file handle when loading files if the handle isn't `NULL`

