### PR TITLE
Offset Floor Depth By Camera Pitch

### DIFF
--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -449,9 +449,10 @@ Fang_DrawMapFloor(
             continue;
 
         /* Calculate row distance, based on perspective at our given height */
-        float row_dist = ((viewport.h / 2.0f) / p) / (1.0f / height);
+        const float row_dist = ((viewport.h / 2.0f) / p) * height;
 
-        framebuf->state.current_depth = row_dist * FANG_PROJECTION_RATIO;
+        framebuf->state.current_depth = row_dist * FANG_PROJECTION_RATIO
+                                      + (1.0f - camera->cam.z);
 
         const Fang_Vec2 floor_step = {
             .x = row_dist * (ray_end.x - ray_start.x) / viewport.w,
@@ -661,11 +662,11 @@ Fang_DrawMapTiles(
 
                 for (int y = start_y; y < end_y; ++y)
                 {
-                    const float r_y = (float)(y - start_y)
-                                    / (float)(end_y - start_y);
-
                     if (y < 0 || y >= viewport.h)
                         continue;
+
+                    const float r_y = (float)(y - start_y)
+                                    / (float)(end_y - start_y);
 
                     Fang_Point tex_pos;
                     {


### PR DESCRIPTION
Resolve #66 

## Description

The depth values of the floor and tile tops clash
when viewed up close while looking downwards. This
commit applies a correction to offset the floor depth
values so that looking downward causes the floor to be
a bit "deeper" - deep enough to not clash with tiles.

## Changes
- Adds missing `const` for floor row distance variable
- Adds inverse of current pitch to floor depth value
- Fixes order of conditional when drawing tile top/bottom

