### PR TITLE
Add Basic Entity Collision

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -91,19 +91,25 @@ Fang_Init(void)
     memset(gamestate.ammo, 0, sizeof(gamestate.ammo));
 
     {
-        Fang_Entity entities [FANG_MAX_ENTITIES] = {
+        Fang_Entity entities[FANG_MAX_ENTITIES] = {
             [0] = (Fang_Entity){
                 .texture = FANG_TEXTURE_NONE,
                 .body = (Fang_Body){
-                    .pos  = (Fang_Vec3){.x = 2.0f, .y = 2.0f},
-                    .size = 1,
+                    .pos  = (Fang_Vec3){.x = 4.0f, .y = 4.0f},
+                    .dir  = gamestate.player.body.dir,
+                    .acc  = gamestate.player.body.acc,
+                    .max  = gamestate.player.body.max,
+                    .size = 0.5f,
                 },
             },
             [1] = (Fang_Entity){
                 .texture = FANG_TEXTURE_NONE,
                 .body = (Fang_Body){
                     .pos  = (Fang_Vec3){.x = 6.0f, .y = 5.5f},
-                    .size = 1,
+                    .dir  = gamestate.player.body.dir,
+                    .acc  = gamestate.player.body.acc,
+                    .max  = gamestate.player.body.max,
+                    .size = 0.5f,
                 },
             },
         };
@@ -244,6 +250,20 @@ Fang_Update(
                 &gamestate.map,
                 &move,
                 FANG_DELTA_TIME_S
+            );
+
+            for (size_t i = 0; i < FANG_MAX_ENTITIES; ++i)
+            {
+                Fang_BodyMove(
+                    &gamestate.entities[i].body,
+                    &gamestate.map,
+                    &(Fang_Vec3){.x = 0.0f},
+                    FANG_DELTA_TIME_S
+                );
+            }
+
+            Fang_BodyCollideBody(
+                &gamestate.player.body, &gamestate.entities[0].body
             );
 
             gamestate.camera.pos = (Fang_Vec3){

--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -262,9 +262,24 @@ Fang_Update(
                 );
             }
 
-            Fang_BodyCollideBody(
-                &gamestate.player.body, &gamestate.entities[0].body
-            );
+            for (size_t i = 0; i < FANG_MAX_ENTITIES; ++i)
+            {
+                Fang_BodyCollideBody(
+                    &gamestate.player.body,
+                    &gamestate.entities[i].body
+                );
+            }
+
+            for (size_t i = 0; i < FANG_MAX_ENTITIES; ++i)
+            {
+                for (size_t j = i + 1; j < FANG_MAX_ENTITIES; ++j)
+                {
+                    Fang_BodyCollideBody(
+                        &gamestate.entities[i].body,
+                        &gamestate.entities[j].body
+                    );
+                }
+            }
 
             gamestate.camera.pos = (Fang_Vec3){
                 .x = gamestate.player.body.pos.x,

--- a/Source/Fang/Fang_Body.c
+++ b/Source/Fang/Fang_Body.c
@@ -240,6 +240,12 @@ Fang_BodyCollideBody(
     assert(a);
     assert(b);
 
+    const bool a_above_b = a->pos.z >= b->pos.z + b->size;
+    const bool b_above_a = b->pos.z >= a->pos.z + a->size;
+
+    if (a_above_b || b_above_a)
+        return false;
+
     const float dx   = a->pos.x - b->pos.x;
     const float dy   = a->pos.y - b->pos.y;
     const float dist = sqrtf(dx * dx + dy * dy);

--- a/Source/Fang/Fang_Body.c
+++ b/Source/Fang/Fang_Body.c
@@ -251,8 +251,8 @@ Fang_BodyCollideBody(
     assert(a);
     assert(b);
 
-    const bool a_above_b = a->pos.z >= b->pos.z + b->size;
-    const bool b_above_a = b->pos.z >= a->pos.z + a->size;
+    const bool a_above_b = a->pos.z > b->pos.z + b->size;
+    const bool b_above_a = b->pos.z > a->pos.z + a->size;
 
     if (a_above_b || b_above_a)
         return false;
@@ -263,24 +263,33 @@ Fang_BodyCollideBody(
 
     if (dist <= a->size + b->size)
     {
+        const bool a_above_b = a->pos.z >= b->pos.z + (b->size * 0.9f);
+        const bool b_above_a = b->pos.z >= a->pos.z + (a->size * 0.9f);
+
         a->pos = a->last;
 
         {
             const Fang_Vec3 temp = a->dir;
-            a->dir = b->dir;
-            b->dir = temp;
+            a->dir = (Fang_Vec3){.x = b->dir.x, .y = b->dir.y, .z = a->dir.z};
+            b->dir = (Fang_Vec3){.x =   temp.x, .y =   temp.y, .z = b->dir.z};
         }
 
-        const Fang_Vec3 temp = Fang_Vec3Multf(a->vel, 10.0f);
+        {
+            const Fang_Vec3 temp = a->vel;
+            a->vel = (Fang_Vec3){.x = b->vel.x, .y = b->vel.y, .z = a->vel.z};
+            b->vel = (Fang_Vec3){.x =   temp.x, .y =   temp.y, .z = b->vel.z};
+        }
 
-        a->vel = Fang_Vec3Multf(b->vel, 10.0f);
-        b->vel = temp;
-
-        a->vel.z = 0.0f;
-        b->vel.z = 0.0f;
-
-        a->jump = false;
-        b->jump = false;
+        if (a_above_b)
+        {
+            a->jump  = false;
+            a->vel.z = 0.0f;
+        }
+        else if (b_above_a)
+        {
+            b->jump  = false;
+            b->vel.z = 0.0f;
+        }
 
         return true;
     }

--- a/Source/Fang/Fang_Body.c
+++ b/Source/Fang/Fang_Body.c
@@ -263,9 +263,6 @@ Fang_BodyCollideBody(
 
     if (dist <= a->size + b->size)
     {
-        const float a_z = a->vel.z;
-        const float b_z = b->vel.z;
-
         a->pos = a->last;
 
         {
@@ -279,8 +276,11 @@ Fang_BodyCollideBody(
         a->vel = Fang_Vec3Multf(b->vel, 10.0f);
         b->vel = temp;
 
-        a->vel.z = a_z;
-        b->vel.z = b_z;
+        a->vel.z = 0.0f;
+        b->vel.z = 0.0f;
+
+        a->jump = false;
+        b->jump = false;
 
         return true;
     }

--- a/Source/Fang/Fang_Body.c
+++ b/Source/Fang/Fang_Body.c
@@ -251,8 +251,8 @@ Fang_BodyCollideBody(
     assert(a);
     assert(b);
 
-    const bool a_above_b = a->pos.z >= b->pos.z + b->size;
-    const bool b_above_a = b->pos.z >= a->pos.z + a->size;
+    const bool a_above_b = a->pos.z > b->pos.z + b->size;
+    const bool b_above_a = b->pos.z > a->pos.z + a->size;
 
     if (a_above_b || b_above_a)
         return false;
@@ -263,24 +263,30 @@ Fang_BodyCollideBody(
 
     if (dist <= a->size + b->size)
     {
-        a->pos = a->last;
-
-        {
-            const Fang_Vec3 temp = a->dir;
-            a->dir = b->dir;
-            b->dir = temp;
-        }
-
-        const Fang_Vec3 temp = Fang_Vec3Multf(a->vel, 10.0f);
-
-        a->vel = Fang_Vec3Multf(b->vel, 10.0f);
-        b->vel = temp;
-
-        a->vel.z = 0.0f;
-        b->vel.z = 0.0f;
-
         a->jump = false;
         b->jump = false;
+
+        if (a->pos.z > b->pos.z && a->vel.z < 0.0f)
+        {
+            a->vel.z = 0.0f;
+            a->pos.z = b->pos.z + b->size;
+            return true;
+        }
+        else if (b->pos.z > a->pos.z && b->vel.z < 0.0f)
+        {
+            b->vel.z = 0.0f;
+            b->pos.z = a->pos.z + a->size;
+            return true;
+        }
+
+        a->pos.x = a->last.x;
+        a->pos.y = a->last.y;
+        b->pos.x = b->last.x;
+        b->pos.y = b->last.y;
+        a->vel.x = 0.0f;
+        a->vel.y = 0.0f;
+        b->vel.x = 0.0f;
+        b->vel.y = 0.0f;
 
         return true;
     }

--- a/Source/Fang/Fang_Body.c
+++ b/Source/Fang/Fang_Body.c
@@ -251,8 +251,8 @@ Fang_BodyCollideBody(
     assert(a);
     assert(b);
 
-    const bool a_above_b = a->pos.z > b->pos.z + b->size;
-    const bool b_above_a = b->pos.z > a->pos.z + a->size;
+    const bool a_above_b = a->pos.z >= b->pos.z + b->size;
+    const bool b_above_a = b->pos.z >= a->pos.z + a->size;
 
     if (a_above_b || b_above_a)
         return false;
@@ -263,33 +263,24 @@ Fang_BodyCollideBody(
 
     if (dist <= a->size + b->size)
     {
-        const bool a_above_b = a->pos.z >= b->pos.z + (b->size * 0.9f);
-        const bool b_above_a = b->pos.z >= a->pos.z + (a->size * 0.9f);
-
         a->pos = a->last;
 
         {
             const Fang_Vec3 temp = a->dir;
-            a->dir = (Fang_Vec3){.x = b->dir.x, .y = b->dir.y, .z = a->dir.z};
-            b->dir = (Fang_Vec3){.x =   temp.x, .y =   temp.y, .z = b->dir.z};
+            a->dir = b->dir;
+            b->dir = temp;
         }
 
-        {
-            const Fang_Vec3 temp = a->vel;
-            a->vel = (Fang_Vec3){.x = b->vel.x, .y = b->vel.y, .z = a->vel.z};
-            b->vel = (Fang_Vec3){.x =   temp.x, .y =   temp.y, .z = b->vel.z};
-        }
+        const Fang_Vec3 temp = Fang_Vec3Multf(a->vel, 10.0f);
 
-        if (a_above_b)
-        {
-            a->jump  = false;
-            a->vel.z = 0.0f;
-        }
-        else if (b_above_a)
-        {
-            b->jump  = false;
-            b->vel.z = 0.0f;
-        }
+        a->vel = Fang_Vec3Multf(b->vel, 10.0f);
+        b->vel = temp;
+
+        a->vel.z = 0.0f;
+        b->vel.z = 0.0f;
+
+        a->jump = false;
+        b->jump = false;
 
         return true;
     }

--- a/Source/Fang/Fang_Camera.c
+++ b/Source/Fang/Fang_Camera.c
@@ -109,6 +109,7 @@ Fang_CameraProjectBody(
           - size
           + offset
           + pitch
+          - (body->pos.z * FANG_PROJECTION_RATIO * dist)
         ),
         .w = (int)size,
         .h = (int)size,

--- a/Source/Fang/Fang_Camera.c
+++ b/Source/Fang/Fang_Camera.c
@@ -94,7 +94,7 @@ Fang_CameraProjectBody(
     const float dist = (viewport->h / plane_pos.y)
                      * (1.0f / FANG_PROJECTION_RATIO);
 
-    const float size   = (body->size    * FANG_PROJECTION_RATIO) * dist / 2.0f;
+    const float size   = (body->size    * FANG_PROJECTION_RATIO) * dist;
     const float offset = (camera->pos.z * FANG_PROJECTION_RATIO) * dist;
     const float pitch  = (camera->cam.z * viewport->h);
 

--- a/Source/Fang/Fang_Constants.c
+++ b/Source/Fang/Fang_Constants.c
@@ -15,10 +15,11 @@
 
 const float FANG_PROJECTION_RATIO = 1.0f / (1.0f / 2.0f);
 
-const float FANG_GRAVITY     = 9.834f;
-const float FANG_RUN_SPEED   = 8.33f; // 30 km/h ~= 8.33 m/s
-const float FANG_JUMP_SPEED  = 3.0f;
-const float FANG_PLAYER_SIZE = 0.3f;
+const float FANG_GRAVITY        = 9.834f;
+const float FANG_RUN_SPEED      = 8.33f; // 30 km/h ~= 8.33 m/s
+const float FANG_JUMP_SPEED     = 3.0f;
+const float FANG_PLAYER_SIZE    = 0.3f;
+const float FANG_JUMP_TOLERANCE = FANG_GRAVITY / 6.0f;
 
 const uint32_t FANG_DELTA_TIME_MS = 10;
 const float    FANG_DELTA_TIME_S = (float)FANG_DELTA_TIME_MS / 1000.0f;

--- a/Source/Fang/Fang_Vector.c
+++ b/Source/Fang/Fang_Vector.c
@@ -43,6 +43,14 @@ Fang_Vec2Multf(
     return (Fang_Vec2){.x = a.x * b, .y = a.y * b};
 }
 
+static inline Fang_Vec3
+Fang_Vec3Multf(
+    const Fang_Vec3 a,
+    const float     b)
+{
+    return (Fang_Vec3){.x = a.x * b, .y = a.y * b, .z = a.z * b};
+}
+
 static inline float
 Fang_Vec2Dot(
     const Fang_Vec2 a,


### PR DESCRIPTION
Resolves #21 

## Description

Adds in collision between entities.

## Changes
- Add `last` position to `Fang_Body`, set at every call to `Fang_BodyMove()`
- Add `jump` state for `Fang_Body`
- Correct logic and threshold for jumping
- Add `Fang_BodyCollideBody()` and run it for all entities on each update
- Correct size projection in `Fang_CameraProjectBody()`
- Add `FANG_JUMP_TOLERANCE`

