### PR TITLE
Limit Input To When Player Is Active

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -140,7 +140,7 @@ Fang_Update(
 
     gamestate.sway.target = (Fang_Vec2){.x = 0.0f, .y = 0.0f};
 
-    if (player)
+    if (player && player->state == FANG_ENTITYSTATE_ACTIVE)
     {
         float forward = 0.0f;
         float left    = 0.0f;


### PR DESCRIPTION
## Description

Usually it's about impossible to have input on the initial frame of the game, but
once we have player death this will be relevant. The player entity should only accept
input control when it is in an active state.

## Changes
- Prevents player input when player is inactive or transitioning states

