### PR TITLE
Update Structure And Function Naming Schemes

### DIFF
--- a/Source/Fang/Fang_Camera.c
+++ b/Source/Fang/Fang_Camera.c
@@ -20,7 +20,7 @@ typedef struct Fang_Camera {
 } Fang_Camera;
 
 static inline void
-Fang_CameraRotate(
+Fang_RotateCamera(
           Fang_Camera * const camera,
     const float               angle,
     const float               pitch)
@@ -43,7 +43,7 @@ Fang_CameraRotate(
 }
 
 static inline Fang_Rect
-Fang_CameraProjectTile(
+Fang_ProjectTile(
     const Fang_Camera   * const camera,
     const Fang_Tile     * const tile,
           float                 dist,
@@ -66,7 +66,7 @@ Fang_CameraProjectTile(
 }
 
 static inline Fang_Rect
-Fang_CameraProjectBody(
+Fang_ProjectBody(
     const Fang_Camera * const camera,
     const Fang_Body   * const body,
     const Fang_Rect   * const viewport,

--- a/Source/Fang/Fang_Chunk.c
+++ b/Source/Fang/Fang_Chunk.c
@@ -18,12 +18,11 @@ typedef size_t Fang_EntityId;
 /**
  * A structure representing which entities are in a given chunk during a frame.
 **/
-typedef struct Fang_ChunkEntitySet Fang_ChunkEntitySet;
-typedef struct Fang_ChunkEntitySet
+typedef struct Fang_ChunkEntities
 {
     Fang_EntityId entities[FANG_CHUNK_ENTITY_CAPACITY];
     size_t        count;
-} Fang_ChunkEntitySet;
+} Fang_ChunkEntities;
 
 /**
  * A structure representing a logical section of the world.
@@ -37,17 +36,17 @@ typedef struct Fang_ChunkEntitySet
  * that position, allowing for varying floor textures across the game map.
 **/
 typedef struct Fang_Chunk {
-    Fang_Tile           tiles[FANG_CHUNK_SIZE][FANG_CHUNK_SIZE];
-    Fang_ChunkEntitySet entities;
-    Fang_TextureId      floor;
+    Fang_Tile          tiles[FANG_CHUNK_SIZE][FANG_CHUNK_SIZE];
+    Fang_ChunkEntities entities;
+    Fang_TextureId     floor;
 } Fang_Chunk;
 
 /**
  * A structure that holds all the available chunks of the game world.
 **/
-typedef struct Fang_ChunkSet {
+typedef struct Fang_Chunks {
     Fang_Chunk chunks[FANG_CHUNK_COUNT];
-} Fang_ChunkSet;
+} Fang_Chunks;
 
 /**
  * Returns the given chunk based on X and Y index values.
@@ -66,9 +65,9 @@ typedef struct Fang_ChunkSet {
 **/
 static const Fang_Chunk *
 Fang_GetIndexedChunk(
-    const Fang_ChunkSet * const chunks,
-    const int8_t                x_index,
-    const int8_t                y_index)
+    const Fang_Chunks * const chunks,
+    const int8_t              x_index,
+    const int8_t              y_index)
 {
     assert(chunks);
 
@@ -139,8 +138,8 @@ Fang_GetIndexedChunk(
 **/
 static inline const Fang_Chunk *
 Fang_GetChunkVec2(
-    const Fang_ChunkSet * const chunks,
-    const Fang_Vec2     * const position)
+    const Fang_Chunks * const chunks,
+    const Fang_Vec2   * const position)
 {
     assert(chunks);
     assert(position);
@@ -167,8 +166,8 @@ Fang_GetChunkVec2(
 **/
 static inline const Fang_Chunk *
 Fang_GetChunkVec3(
-    const Fang_ChunkSet * const chunks,
-    const Fang_Vec3     * const position)
+    const Fang_Chunks * const chunks,
+    const Fang_Vec3   * const position)
 {
     assert(chunks);
     assert(position);
@@ -192,8 +191,8 @@ Fang_GetChunkVec3(
 **/
 static inline const Fang_Chunk *
 Fang_GetChunkPoint(
-    const Fang_ChunkSet * const chunks,
-    const Fang_Point    * const position)
+    const Fang_Chunks * const chunks,
+    const Fang_Point  * const position)
 {
     assert(chunks);
     assert(position);
@@ -242,8 +241,8 @@ Fang_GetChunkPoint(
 **/
 static inline const Fang_Tile *
 Fang_GetChunkTileVec2(
-    const Fang_ChunkSet * const chunks,
-    const Fang_Vec2     * const position)
+    const Fang_Chunks * const chunks,
+    const Fang_Vec2   * const position)
 {
     assert(chunks);
     assert(position);
@@ -279,8 +278,8 @@ Fang_GetChunkTileVec2(
 **/
 static inline const Fang_Tile *
 Fang_GetChunkTileVec3(
-    const Fang_ChunkSet * const chunks,
-    const Fang_Vec3     * const position)
+    const Fang_Chunks * const chunks,
+    const Fang_Vec3   * const position)
 {
     assert(chunks);
     assert(position);
@@ -295,8 +294,8 @@ Fang_GetChunkTileVec3(
 **/
 static inline const Fang_Tile *
 Fang_GetChunkTilePoint(
-    const Fang_ChunkSet * const chunks,
-    const Fang_Point    * const position)
+    const Fang_Chunks * const chunks,
+    const Fang_Point  * const position)
 {
     assert(chunks);
     assert(position);

--- a/Source/Fang/Fang_Color.c
+++ b/Source/Fang/Fang_Color.c
@@ -32,7 +32,7 @@ typedef struct Fang_Color {
  * Maps RGBA components of a Fang_Color to a 32-bit, unsigned integer.
 **/
 static inline uint32_t
-Fang_ColorToRGBA(
+Fang_MapColor(
     const Fang_Color * const color)
 {
     assert(color);
@@ -49,7 +49,7 @@ Fang_ColorToRGBA(
  * Maps a 32-bit, unsigned integer to RGBA components of a Fang_Color.
 **/
 static inline Fang_Color
-Fang_ColorFromRGBA(
+Fang_GetColor(
     uint32_t color)
 {
     Fang_Color result;
@@ -64,7 +64,7 @@ Fang_ColorFromRGBA(
  * Performs alpha blending on two colors.
 **/
 static inline Fang_Color
-Fang_ColorBlend(
+Fang_BlendColor(
     const Fang_Color * const source,
     const Fang_Color * const dest)
 {

--- a/Source/Fang/Fang_Constants.c
+++ b/Source/Fang/Fang_Constants.c
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-const float FANG_PROJECTION_RATIO = 1.0f / (1.0f / 2.0f);
+static const float FANG_PROJECTION_RATIO = 1.0f / (1.0f / 2.0f);
 
 enum {
     FANG_CHUNK_SIZE  = 16,
@@ -23,14 +23,39 @@ enum {
     FANG_CHUNK_MIN = -(1 << 6),
 };
 
-const float FANG_GRAVITY        = 9.834f;
-const float FANG_RUN_SPEED      = 8.33f; // 30 km/h ~= 8.33 m/s
-const float FANG_JUMP_SPEED     = 3.0f;
-const float FANG_PLAYER_WIDTH   = 0.35f;
-const float FANG_PLAYER_HEIGHT  = 0.35f;
-const float FANG_PICKUP_WIDTH   = FANG_PLAYER_WIDTH  / 2.0f;
-const float FANG_PICKUP_HEIGHT  = FANG_PLAYER_HEIGHT / 2.0f;
-const float FANG_JUMP_TOLERANCE = FANG_GRAVITY / 6.0f;
+static const float FANG_GRAVITY        = 9.834f;
+static const float FANG_RUN_SPEED      = 8.33f; // 30 km/h ~= 8.33 m/s
+static const float FANG_JUMP_SPEED     = 3.0f;
+static const float FANG_PLAYER_WIDTH   = 0.35f;
+static const float FANG_PLAYER_HEIGHT  = 0.35f;
+static const float FANG_PICKUP_WIDTH   = FANG_PLAYER_WIDTH  / 2.0f;
+static const float FANG_PICKUP_HEIGHT  = FANG_PLAYER_HEIGHT / 2.0f;
+static const float FANG_JUMP_TOLERANCE = FANG_GRAVITY / 6.0f;
 
-const uint32_t FANG_DELTA_TIME_MS = 10;
-const float    FANG_DELTA_TIME_S = (float)FANG_DELTA_TIME_MS / 1000.0f;
+static const uint32_t FANG_DELTA_TIME_MS = 10;
+static const float    FANG_DELTA_TIME_S = (float)FANG_DELTA_TIME_MS / 1000.0f;
+
+/**
+ * A constant representing the width|height of a tile texture.
+**/
+enum {
+    FANG_TEXTURE_SIZE = 128,
+};
+
+/**
+ * All fonts should be 8x9 in size, with a 1px barrier in between each
+ * character.
+**/
+enum {
+    FANG_FONT_HEIGHT = 9,
+    FANG_FONT_WIDTH  = 8,
+};
+
+enum {
+    FANG_RAY_MAX_STEPS = 64,
+};
+
+enum {
+    FANG_MAX_ENTITIES   = 256,
+    FANG_MAX_COLLISIONS = FANG_MAX_ENTITIES * 64,
+};

--- a/Source/Fang/Fang_DDA.c
+++ b/Source/Fang/Fang_DDA.c
@@ -40,7 +40,7 @@ typedef struct Fang_DDAState {
  * Initializes the DDA based on a given starting position and direction vector.
 **/
 static inline void
-Fang_DDAInit(
+Fang_InitDDA(
           Fang_DDAState * const dda,
     const Fang_Vec2     * const start,
     const Fang_Vec2     * const dir)
@@ -94,7 +94,7 @@ Fang_DDAInit(
  * position to the current point.
 **/
 static float
-Fang_DDAStep(
+Fang_StepDDA(
     Fang_DDAState * const dda)
 {
     assert(dda);

--- a/Source/Fang/Fang_Entity.c
+++ b/Source/Fang/Fang_Entity.c
@@ -13,10 +13,7 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-enum {
-    FANG_MAX_ENTITIES   = 256,
-    FANG_MAX_COLLISIONS = FANG_MAX_ENTITIES * 64,
-};
+typedef size_t Fang_EntityId;
 
 /**
  * The life-cycle state that the entity is in.
@@ -47,8 +44,6 @@ typedef enum Fang_EntityType {
     FANG_ENTITYTYPE_AMMO,
     FANG_ENTITYTYPE_PROJECTILE,
 } Fang_EntityType;
-
-typedef size_t Fang_EntityId;
 
 /**
  * Properties specific to health pickup entity types.
@@ -122,31 +117,31 @@ typedef struct Fang_EntityCollision {
 } Fang_EntityCollision;
 
 /**
- * A set used to hold collisions between entities for a given frame.
+ * A structure used to hold collisions between entities for a given frame.
 **/
-typedef struct Fang_EntityCollisionSet {
+typedef struct Fang_EntityCollisions {
     Fang_EntityCollision collisions[FANG_MAX_COLLISIONS];
-    size_t          count;
-} Fang_EntityCollisionSet;
+    size_t               count;
+} Fang_EntityCollisions;
 
 /**
- * A set used to hold entities and information about them.
+ * A structure used to hold entities and information about them.
  *
  * This structure holds the entity array used to manage and query entities. It
  * also maintains the collision tables for both the current and previous frame.
 **/
-typedef struct Fang_EntitySet {
-    Fang_Entity              entities[FANG_MAX_ENTITIES];
-    Fang_EntityId            last_index;
-    Fang_EntityCollisionSet  collisions;
-    Fang_EntityCollisionSet  last_collisions;
-} Fang_EntitySet;
+typedef struct Fang_Entities {
+    Fang_Entity            entities[FANG_MAX_ENTITIES];
+    Fang_EntityId          last_index;
+    Fang_EntityCollisions  collisions;
+    Fang_EntityCollisions  last_collisions;
+} Fang_Entities;
 
 /**
  * Returns the relevant texture for the entity's entity type.
 **/
 static inline Fang_TextureId
-Fang_EntityQueryTexture(
+Fang_GetEntityTexture(
     const Fang_Entity * const entity)
 {
     assert(entity);
@@ -170,9 +165,9 @@ Fang_EntityQueryTexture(
  * a null pointer.
 **/
 static inline Fang_Entity *
-Fang_EntitySetQuery(
-          Fang_EntitySet * const entities,
-    const Fang_EntityId          entity_id)
+Fang_GetEntity(
+          Fang_Entities * const entities,
+    const Fang_EntityId         entity_id)
 {
     assert(entities);
     assert(entity_id < FANG_MAX_ENTITIES);
@@ -197,9 +192,9 @@ Fang_EntitySetQuery(
  * exceeds the maximum this function will do nothing.
 **/
 static inline Fang_EntityId
-Fang_EntitySetAdd(
-          Fang_EntitySet * const entities,
-    const Fang_Entity    * const initial)
+Fang_AddEntity(
+          Fang_Entities * const entities,
+    const Fang_Entity   * const initial)
 {
     assert(entities);
     assert(entities->last_index < FANG_MAX_ENTITIES);
@@ -216,7 +211,7 @@ Fang_EntitySetAdd(
     }
 
     const bool last_index_valid = result < FANG_MAX_ENTITIES - 1;
-    const bool last_index_open  = !Fang_EntitySetQuery(
+    const bool last_index_open  = !Fang_GetEntity(
         entities, entities->last_index + 1
     );
 
@@ -232,7 +227,7 @@ Fang_EntitySetAdd(
             if (i == result)
                 continue;
 
-            if (!Fang_EntitySetQuery(entities, i))
+            if (!Fang_GetEntity(entities, i))
             {
                 entities->last_index = i;
                 break;
@@ -254,9 +249,9 @@ Fang_EntitySetAdd(
  * a set maximum number of entities.
 **/
 static inline void
-Fang_EntitySetRemove(
-          Fang_EntitySet * const entities,
-    const Fang_EntityId          entity_id)
+Fang_RemoveEntity(
+          Fang_Entities * const entities,
+    const Fang_EntityId         entity_id)
 {
     assert(entities);
     assert(entity_id < FANG_MAX_ENTITIES);
@@ -270,9 +265,9 @@ Fang_EntitySetRemove(
  * collision has not already been recorded.
 **/
 static inline void
-Fang_EntityCollisionSetAdd(
-          Fang_EntityCollisionSet * const collisions,
-    const Fang_EntityCollision                 pair)
+Fang_AddEntityCollision(
+          Fang_EntityCollisions * const collisions,
+    const Fang_EntityCollision          pair)
 {
     assert(collisions);
     assert(pair.first != pair.second);

--- a/Source/Fang/Fang_Image.c
+++ b/Source/Fang/Fang_Image.c
@@ -45,7 +45,7 @@ Fang_ImageValid(
  * stride (bytes per pixel) and set the image pitch appropriately.
 **/
 static inline int
-Fang_ImageAlloc(
+Fang_AllocImage(
           Fang_Image * const image,
     const int                width,
     const int                height,
@@ -76,7 +76,7 @@ Fang_ImageAlloc(
  * nothing.
 **/
 static inline void
-Fang_ImageFree(
+Fang_FreeImage(
     Fang_Image * const image)
 {
     if (Fang_ImageValid(image))
@@ -95,7 +95,7 @@ Fang_ImageFree(
  * The image must have a valid pixel data pointer.
 **/
 static inline void
-Fang_ImageClear(
+Fang_ClearImage(
     Fang_Image * const image)
 {
     assert(Fang_ImageValid(image));
@@ -110,7 +110,7 @@ Fang_ImageClear(
  * to 255.
 **/
 static inline Fang_Color
-Fang_ImageQuery(
+Fang_GetPixel(
     const Fang_Image * const image,
     const Fang_Point * const point)
 {
@@ -146,5 +146,5 @@ Fang_ImageQuery(
         pixel |= 0x000000FF;
     }
 
-    return Fang_ColorFromRGBA(pixel);
+    return Fang_GetColor(pixel);
 }

--- a/Source/Fang/Fang_Input.c
+++ b/Source/Fang/Fang_Input.c
@@ -123,8 +123,6 @@ typedef struct Fang_InputText {
 
 /**
  * A structure representing the input state for a given frame.
- *
- * @see Fang_InputClear()
 **/
 typedef struct Fang_Input {
     Fang_InputId         id;
@@ -167,7 +165,7 @@ Fang_InputReleased(
  * text buffer.
 **/
 static void
-Fang_InputReset(
+Fang_ClearInput(
     Fang_Input * const input)
 {
     assert(input);

--- a/Source/Fang/Fang_Interface.c
+++ b/Source/Fang/Fang_Interface.c
@@ -65,7 +65,7 @@ typedef struct Fang_Interface {
     Fang_InterfaceTheme theme;
 
           Fang_Framebuffer * framebuf;
-    const Fang_TextureSet       * textures;
+    const Fang_Textures    * textures;
     const Fang_Input       * input;
 } Fang_Interface;
 
@@ -78,7 +78,7 @@ typedef struct Fang_Interface {
  * This should be called at the beginning of each frame.
 **/
 static inline void
-Fang_InterfaceUpdate(
+Fang_UpdateInterface(
     Fang_Interface * const interface)
 {
     assert(interface);
@@ -98,6 +98,8 @@ Fang_InterfaceButton(
 {
     assert(interface);
     assert(bounds);
+
+    const Fang_InterfaceTheme * const theme = &interface->theme;
 
     const uint32_t id = ++interface->id;
 
@@ -140,22 +142,22 @@ Fang_InterfaceButton(
         const bool active = interface->active == id;
 
         if (active)
-            Fang_FillRect(framebuf, bounds, &interface->theme.colors.highlight);
+            Fang_FillRect(framebuf, bounds, &theme->colors.highlight);
         else if (hot)
-            Fang_DrawRect(framebuf, bounds, &interface->theme.colors.foreground);
+            Fang_DrawRect(framebuf, bounds, &theme->colors.foreground);
         else
-            Fang_DrawRect(framebuf, bounds, &interface->theme.colors.disabled);
+            Fang_DrawRect(framebuf, bounds, &theme->colors.disabled);
 
         if (text)
         {
-            const Fang_Rect text_area = Fang_RectResize(
+            const Fang_Rect text_area = Fang_ResizeRect(
                 bounds, -4, -bounds->h / 2
             );
 
             Fang_DrawText(
                 framebuf,
                 text,
-                Fang_TextureSetQuery(interface->textures, interface->theme.font),
+                Fang_GetTexture(interface->textures, theme->font),
                 text_area.h,
                 &(Fang_Point){
                     .x = (
@@ -180,6 +182,8 @@ Fang_InterfaceSlider(
 {
     assert(interface);
     assert(bounds);
+
+    const Fang_InterfaceTheme * const theme = &interface->theme;
 
     const uint32_t id = ++interface->id;
 
@@ -243,15 +247,15 @@ Fang_InterfaceSlider(
         Fang_Color color;
 
         if (active)
-            color = interface->theme.colors.foreground;
+            color = theme->colors.foreground;
         else if (hot)
-            color = interface->theme.colors.highlight;
+            color = theme->colors.highlight;
         else
-            color = interface->theme.colors.disabled;
+            color = theme->colors.disabled;
 
         Fang_DrawRect(framebuf, bounds, &color);
 
-        Fang_Rect fill_area = Fang_RectResize(bounds, -1, -1);
+        Fang_Rect fill_area = Fang_ResizeRect(bounds, -1, -1);
 
         Fang_FillRect(
             framebuf,
@@ -274,14 +278,14 @@ Fang_InterfaceSlider(
 
             if (display_text)
             {
-                const Fang_Rect text_area = Fang_RectResize(
+                const Fang_Rect text_area = Fang_ResizeRect(
                     bounds, -4, -bounds->h / 2
                 );
 
                 Fang_DrawText(
                     framebuf,
                     display_text,
-                    Fang_TextureSetQuery(interface->textures, interface->theme.font),
+                    Fang_GetTexture(interface->textures, theme->font),
                     text_area.h,
                     &(Fang_Point){
                         .x = (

--- a/Source/Fang/Fang_Lerp.c
+++ b/Source/Fang/Fang_Lerp.c
@@ -26,12 +26,12 @@ typedef struct Fang_LerpVec3 {
 } Fang_LerpVec3;
 
 #define Fang_Lerp(value, delta) _Generic(value,  \
-    Fang_LerpVec2*: Fang_LerpVec2Step, \
-    Fang_LerpVec3*: Fang_LerpVec3Step  \
+    Fang_LerpVec2*: Fang_StepLerpVec2, \
+    Fang_LerpVec3*: Fang_StepLerpVec3  \
     )(value, delta)
 
 static inline void
-Fang_LerpVec2Step(
+Fang_StepLerpVec2(
           Fang_LerpVec2 * const vec,
     const float                 delta)
 {
@@ -52,7 +52,7 @@ Fang_LerpVec2Step(
 }
 
 static inline void
-Fang_LerpVec3Step(
+Fang_StepLerpVec3(
           Fang_LerpVec3 * const vec,
     const float                 delta)
 {

--- a/Source/Fang/Fang_Map.c
+++ b/Source/Fang/Fang_Map.c
@@ -13,10 +13,13 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * A structure representing the current world loaded in the game.
+**/
 typedef struct Fang_Map {
     Fang_TextureId skybox;
     Fang_TextureId floor;
     Fang_Color     fog;
     float          fog_distance;
-    Fang_ChunkSet  chunks;
+    Fang_Chunks    chunks;
 } Fang_Map;

--- a/Source/Fang/Fang_Matrix.c
+++ b/Source/Fang/Fang_Matrix.c
@@ -13,34 +13,34 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-typedef struct Fang_Mat3x3 {
+typedef struct Fang_Matrix {
     float m00, m01, m02,
           m10, m11, m12,
           m20, m21, m22;
-} Fang_Mat3x3;
+} Fang_Matrix;
 
-#define Fang_MatMult(a, b) _Generic(b,   \
-        Fang_Vec3:   Fang_Mat3x3Multv3,  \
-        Fang_Point:  Fang_Mat3x3Multp,   \
-        Fang_Mat3x3: Fang_Mat3x3Mult     \
+#define Fang_MultMatrix(a, b) _Generic(b, \
+        Fang_Matrix: Fang_MultMatrices,   \
+        Fang_Vec3:   Fang_MultMatrixVec3, \
+        Fang_Point:  Fang_MultMatrixPoint \
     )(a, b)
 
-static inline Fang_Mat3x3
-Fang_Mat3x3Identity(void)
+static inline Fang_Matrix
+Fang_IdentityMatrix(void)
 {
-    return (Fang_Mat3x3){
+    return (Fang_Matrix){
         1.0f, 0.0f, 0.0f,
         0.0f, 1.0f, 0.0f,
         0.0f, 0.0f, 1.0f,
     };
 }
 
-static inline Fang_Mat3x3
-Fang_Mat3x3Mult(
-    const Fang_Mat3x3 a,
-    const Fang_Mat3x3 b)
+static inline Fang_Matrix
+Fang_MultMatrices(
+    const Fang_Matrix a,
+    const Fang_Matrix b)
 {
-    return (Fang_Mat3x3){
+    return (Fang_Matrix){
         a.m00 * b.m00 + a.m01 * b.m10 + a.m02 * b.m20,
         a.m00 * b.m01 + a.m01 * b.m11 + a.m02 * b.m21,
         a.m00 * b.m02 + a.m01 * b.m12 + a.m02 * b.m22,
@@ -56,8 +56,8 @@ Fang_Mat3x3Mult(
 }
 
 static inline Fang_Vec3
-Fang_Mat3x3Multv3(
-    const Fang_Mat3x3 a,
+Fang_MultMatrixVec3(
+    const Fang_Matrix a,
     const Fang_Vec3   b)
 {
     return (Fang_Vec3){
@@ -68,35 +68,35 @@ Fang_Mat3x3Multv3(
 }
 
 static inline Fang_Point
-Fang_Mat3x3Multp(
-    const Fang_Mat3x3 a,
+Fang_MultMatrixPoint(
+    const Fang_Matrix a,
     const Fang_Point  b)
 {
-    const Fang_Vec3 result = Fang_Mat3x3Multv3(
+    const Fang_Vec3 result = Fang_MultMatrixVec3(
         a, (Fang_Vec3){.x = b.x, .y = b.y, .z = 1.0f}
     );
 
     return (Fang_Point){.x = (int)result.x, .y = (int)result.y};
 }
 
-static inline Fang_Mat3x3
-Fang_Mat3x3Translate(
+static inline Fang_Matrix
+Fang_TranslateMatrix(
     const float x,
     const float y)
 {
-    return (Fang_Mat3x3){
+    return (Fang_Matrix){
         1.0f, 0.0f,    x,
         0.0f, 1.0f,    y,
         0.0f, 0.0f, 1.0f,
     };
 }
 
-static inline Fang_Mat3x3
-Fang_Mat3x3Scale(
+static inline Fang_Matrix
+Fang_ScaleMatrix(
     const float x,
     const float y)
 {
-    return (Fang_Mat3x3){
+    return (Fang_Matrix){
            x, 0.0f, 0.0f,
         0.0f,    y, 0.0f,
         0.0f, 0.0f, 1.0f,

--- a/Source/Fang/Fang_Pickups.c
+++ b/Source/Fang/Fang_Pickups.c
@@ -14,15 +14,15 @@
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 static inline Fang_EntityId
-Fang_AmmoCreate(
-          Fang_EntitySet  * const entities,
+Fang_CreateAmmo(
+          Fang_Entities   * const entities,
     const Fang_WeaponType         type,
     const int                     count,
     const Fang_Vec3               pos)
 {
     assert(entities);
 
-    return Fang_EntitySetAdd(
+    return Fang_AddEntity(
         entities,
         &(Fang_Entity){
             .type = FANG_ENTITYTYPE_AMMO,
@@ -42,7 +42,7 @@ Fang_AmmoCreate(
 }
 
 static inline void
-Fang_AmmoUpdate(
+Fang_UpdateAmmo(
           Fang_State  * const state,
           Fang_Entity * const ammo,
     const uint32_t            delta)
@@ -56,7 +56,7 @@ Fang_AmmoUpdate(
 
     if (ammo->state == FANG_ENTITYSTATE_REMOVING)
     {
-        Fang_EntitySetRemove(&state->entities, ammo->id);
+        Fang_RemoveEntity(&state->entities, ammo->id);
         return;
     }
 
@@ -64,14 +64,14 @@ Fang_AmmoUpdate(
         ammo->state = FANG_ENTITYSTATE_ACTIVE;
 }
 
-void
+static inline void
 Fang_AmmoCollideMap(
     Fang_Entity * const ammo)
 {
     assert(ammo);
 }
 
-void
+static inline void
 Fang_AmmoCollideEntity(
           Fang_Entity * const ammo,
           Fang_Entity * const entity,
@@ -110,14 +110,14 @@ Fang_AmmoCollideEntity(
 }
 
 static inline Fang_EntityId
-Fang_HealthCreate(
-          Fang_EntitySet * const entities,
-    const int                    count,
-    const Fang_Vec3              pos)
+Fang_CreateHealth(
+          Fang_Entities * const entities,
+    const int                   count,
+    const Fang_Vec3             pos)
 {
     assert(entities);
 
-    return Fang_EntitySetAdd(
+    return Fang_AddEntity(
         entities,
         &(Fang_Entity){
             .type = FANG_ENTITYTYPE_HEALTH,
@@ -136,7 +136,7 @@ Fang_HealthCreate(
 }
 
 static inline void
-Fang_HealthUpdate(
+Fang_UpdateHealth(
           Fang_State  * const state,
           Fang_Entity * const health,
     const uint32_t            delta)
@@ -150,7 +150,7 @@ Fang_HealthUpdate(
 
     if (health->state == FANG_ENTITYSTATE_REMOVING)
     {
-        Fang_EntitySetRemove(&state->entities, health->id);
+        Fang_RemoveEntity(&state->entities, health->id);
         return;
     }
 
@@ -158,14 +158,14 @@ Fang_HealthUpdate(
         health->state = FANG_ENTITYSTATE_ACTIVE;
 }
 
-void
+static inline void
 Fang_HealthCollideMap(
     Fang_Entity * const health)
 {
     assert(health);
 }
 
-void
+static inline void
 Fang_HealthCollideEntity(
           Fang_Entity * const health,
           Fang_Entity * const entity,

--- a/Source/Fang/Fang_Player.c
+++ b/Source/Fang/Fang_Player.c
@@ -13,17 +13,16 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 static inline Fang_EntityId
-Fang_PlayerCreate(
-          Fang_EntitySet  * const entities,
-    const Fang_InputId            input,
-    const Fang_Vec3               pos,
-    const Fang_Vec3               dir)
+Fang_CreatePlayer(
+          Fang_Entities * const entities,
+    const Fang_InputId          input,
+    const Fang_Vec3             pos,
+    const Fang_Vec3             dir)
 {
     assert(entities);
 
-    return Fang_EntitySetAdd(
+    return Fang_AddEntity(
         entities,
         &(Fang_Entity){
             .type = FANG_ENTITYTYPE_PLAYER,
@@ -52,8 +51,8 @@ Fang_PlayerCreate(
     );
 }
 
-void
-Fang_PlayerUpdate(
+static inline void
+Fang_UpdatePlayer(
           Fang_State  * const state,
           Fang_Entity * const player,
     const uint32_t            delta)
@@ -65,7 +64,7 @@ Fang_PlayerUpdate(
 
     if (player->state == FANG_ENTITYSTATE_REMOVING)
     {
-        Fang_EntitySetRemove(&state->entities, player->id);
+        Fang_RemoveEntity(&state->entities, player->id);
         return;
     }
 
@@ -81,14 +80,14 @@ Fang_PlayerUpdate(
     }
 }
 
-void
+static inline void
 Fang_PlayerCollideMap(
     Fang_Entity * const player)
 {
     assert(player);
 }
 
-void
+static inline void
 Fang_PlayerCollideEntity(
           Fang_Entity * const player,
           Fang_Entity * const entity,
@@ -101,18 +100,18 @@ Fang_PlayerCollideEntity(
     (void)initial_collision;
 }
 
-void
+static inline void
 Fang_PlayerFireWeapon(
-          Fang_Entity    * const player,
-          Fang_EntitySet * const entities,
-    const bool                   initial_fire)
+          Fang_Entity   * const player,
+          Fang_Entities * const entities,
+    const bool                  initial_fire)
 {
     assert(player);
     assert(player->state == FANG_ENTITYSTATE_ACTIVE);
     assert(entities);
 
           Fang_PlayerProps * const props  = &player->props.player;
-    const Fang_Weapon      * const weapon = Fang_WeaponQuery(props->weapon);
+    const Fang_Weapon      * const weapon = Fang_GetWeapon(props->weapon);
 
     if (!weapon)
         return;
@@ -132,5 +131,5 @@ Fang_PlayerFireWeapon(
 
     props->cooldown = weapon->cooldown;
 
-    Fang_ProjectileCreate(entities, props->weapon, player->id);
+    Fang_CreateProjectile(entities, props->weapon, player->id);
 }

--- a/Source/Fang/Fang_Projectiles.c
+++ b/Source/Fang/Fang_Projectiles.c
@@ -14,21 +14,21 @@
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 static inline Fang_EntityId
-Fang_ProjectileCreate(
-          Fang_EntitySet  * const entities,
+Fang_CreateProjectile(
+          Fang_Entities   * const entities,
     const Fang_WeaponType         type,
     const Fang_EntityId           owner_id)
 {
     assert(entities);
 
-    const Fang_Entity * const owner  = Fang_EntitySetQuery(entities, owner_id);
-    const Fang_Weapon * const weapon = Fang_WeaponQuery(type);
+    const Fang_Entity * const owner  = Fang_GetEntity(entities, owner_id);
+    const Fang_Weapon * const weapon = Fang_GetWeapon(type);
 
     assert(weapon);
     assert(owner);
     assert(owner->state);
 
-    return Fang_EntitySetAdd(
+    return Fang_AddEntity(
         entities,
         &(Fang_Entity){
             .type = FANG_ENTITYTYPE_PROJECTILE,
@@ -65,7 +65,7 @@ Fang_ProjectileCreate(
 }
 
 static inline void
-Fang_ProjectileUpdate(
+Fang_UpdateProjectile(
           Fang_State  * const state,
           Fang_Entity * const projectile,
     const uint32_t            delta)
@@ -85,7 +85,7 @@ Fang_ProjectileUpdate(
 
     if (projectile->state == FANG_ENTITYSTATE_REMOVING)
     {
-        Fang_EntitySetRemove(&state->entities, projectile->id);
+        Fang_RemoveEntity(&state->entities, projectile->id);
         return;
     }
 
@@ -97,10 +97,10 @@ Fang_ProjectileUpdate(
     else
         props->lifespan -= delta;
 
-    Fang_BodySetTargetVelocity(&projectile->body, props->speed, 0.0f);
+    Fang_SetTargetVelocity(&projectile->body, props->speed, 0.0f);
 }
 
-void
+static inline void
 Fang_ProjectileCollideMap(
     Fang_Entity * const projectile)
 {
@@ -109,7 +109,7 @@ Fang_ProjectileCollideMap(
     projectile->state = FANG_ENTITYSTATE_REMOVING;
 }
 
-void
+static inline void
 Fang_ProjectileCollideEntity(
           Fang_Entity * const projectile,
           Fang_Entity * const entity,

--- a/Source/Fang/Fang_Rect.c
+++ b/Source/Fang/Fang_Rect.c
@@ -13,10 +13,16 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * An integral, 2D position in space.
+**/
 typedef struct Fang_Point {
     int x, y;
 } Fang_Point;
 
+/**
+ * An integral, 2D area in space.
+**/
 typedef struct Fang_Rect {
     int x, y, w, h;
 } Fang_Rect;
@@ -26,7 +32,7 @@ typedef struct Fang_Rect {
  * destination rectangle.
 **/
 static inline Fang_Rect
-Fang_RectClip(
+Fang_ClipRect(
     const Fang_Rect * const source,
     const Fang_Rect * const dest)
 {
@@ -64,7 +70,7 @@ Fang_RectContains(
  * Grows or shrinks a rectangle in each dimension by a given pixel amount.
 **/
 static inline Fang_Rect
-Fang_RectResize(
+Fang_ResizeRect(
     const Fang_Rect * const rect,
     const int               x,
     const int               y)

--- a/Source/Fang/Fang_State.c
+++ b/Source/Fang/Fang_State.c
@@ -13,20 +13,31 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * A structure representing the in-game Unix time.
+ *
+ * An accumulator is included here for use in the fixed-step update loop.
+**/
 typedef struct Fang_Clock {
     uint32_t time;
     uint32_t accumulator;
 } Fang_Clock;
 
+/**
+ * The current state of the game.
+ *
+ * While this structure holds all the necessary data for the game to run, it is
+ * not indicative of the game's "save state".
+**/
 typedef struct Fang_State {
-    Fang_Map        map;
-    Fang_TextureSet textures;
-    Fang_Ray        raycast[FANG_WINDOW_SIZE];
-    Fang_Clock      clock;
-    Fang_Camera     camera;
-    Fang_EntityId   player;
-    Fang_Interface  interface;
-    Fang_EntitySet  entities;
-    Fang_LerpVec2   sway;
-    float           bob;
+    Fang_Map       map;
+    Fang_Textures  textures;
+    Fang_Ray       raycast[FANG_WINDOW_SIZE];
+    Fang_Clock     clock;
+    Fang_Camera    camera;
+    Fang_EntityId  player;
+    Fang_Interface interface;
+    Fang_Entities  entities;
+    Fang_LerpVec2  sway;
+    float          bob;
 } Fang_State;

--- a/Source/Fang/Fang_TGA.c
+++ b/Source/Fang/Fang_TGA.c
@@ -14,7 +14,7 @@
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Parses a TGA file in memory.
+ * Parses TGA file data.
  *
  * This function does not support the following TGA features:
  * - Bit depths other than 8, 24, or 32
@@ -24,7 +24,7 @@
  * - Images with an origin other than top-left
 **/
 static Fang_Image
-Fang_TGAParse(
+Fang_ParseTGA(
     Fang_File * const file)
 {
     assert(file);
@@ -119,7 +119,7 @@ Fang_TGAParse(
     if (header.descriptor & TGA_ORIGIN_RIGHT)
         goto Error_Unsupported;
 
-    if (Fang_ImageAlloc(&result, header.width, header.height, header.depth))
+    if (Fang_AllocImage(&result, header.width, header.height, header.depth))
         goto Error_Allocation;
 
     /* Image ID and color map unused */
@@ -230,12 +230,12 @@ Fang_TGAParse(
 
 Error_Allocation:
 Error_Unsupported:
-    Fang_ImageFree(&result);
+    Fang_FreeImage(&result);
     return result;
 }
 
 static inline Fang_Image
-Fang_TGALoad(
+Fang_LoadTGA(
     const char * const filepath)
 {
     Fang_Image result = {.pixels = NULL};
@@ -244,7 +244,7 @@ Fang_TGALoad(
     if (Fang_LoadFile(filepath, &file) != 0)
         return result;
 
-    result = Fang_TGAParse(&file);
+    result = Fang_ParseTGA(&file);
     Fang_FreeFile(&file);
     return result;
 }

--- a/Source/Fang/Fang_Weapon.c
+++ b/Source/Fang/Fang_Weapon.c
@@ -13,6 +13,9 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * The available weapon types in the game.
+**/
 typedef enum Fang_WeaponType {
     FANG_WEAPONTYPE_PISTOL,
     FANG_WEAPONTYPE_CARBINE,
@@ -26,6 +29,18 @@ typedef enum Fang_WeaponType {
     FANG_WEAPONTYPE_NONE,
 } Fang_WeaponType;
 
+/**
+ * A structure detailing the properties of an in-game weapon.
+ *
+ * Weapons have various properties that determine their behavior when firing,
+ * such as how quickly they can fire, whether they fire automatically, how much
+ * damage or speed the projectile should have, and how long the projectile
+ * should stay active before de-spawning.
+ *
+ * The texture of a weapon controls the image displayed in the first person
+ * view. If no texture has been assigned then the weapon will not render in the
+ * HUD.
+**/
 typedef struct Fang_Weapon {
     char           * name;
     Fang_TextureId   texture;
@@ -36,8 +51,13 @@ typedef struct Fang_Weapon {
     uint32_t         lifespan;
 } Fang_Weapon;
 
+/**
+ * Retrieves weapon details given a weapon-id.
+ *
+ * If the type is 'none' this will return NULL.
+**/
 static inline const Fang_Weapon *
-Fang_WeaponQuery(
+Fang_GetWeapon(
     const Fang_WeaponType type)
 {
     if (type == FANG_WEAPONTYPE_NONE)

--- a/Source/Platform/FangSDL.c
+++ b/Source/Platform/FangSDL.c
@@ -143,7 +143,7 @@ int Fang_Main(int argc, char** argv)
     bool quit = false;
     while (!quit)
     {
-        Fang_InputReset(&input);
+        Fang_ClearInput(&input);
 
         SDL_Event event;
         while (SDL_PollEvent(&event))
@@ -343,16 +343,16 @@ int Fang_Main(int argc, char** argv)
 
         {
             Fang_Framebuffer framebuf;
-            framebuf.color.width   = FANG_WINDOW_SIZE;
-            framebuf.color.height  = FANG_WINDOW_SIZE;
-            framebuf.color.stride  = SDL_BYTESPERPIXEL(SDL_PIXELFORMAT_RGBA8888);
-            framebuf.depth.width   = FANG_WINDOW_SIZE;
-            framebuf.depth.height  = FANG_WINDOW_SIZE;
-            framebuf.depth.stride  = SDL_BYTESPERPIXEL(SDL_PIXELFORMAT_RGBA8888);
+            framebuf.color.width  = FANG_WINDOW_SIZE;
+            framebuf.color.height = FANG_WINDOW_SIZE;
+            framebuf.color.stride = SDL_BYTESPERPIXEL(SDL_PIXELFORMAT_RGBA8888);
+            framebuf.depth.width  = FANG_WINDOW_SIZE;
+            framebuf.depth.height = FANG_WINDOW_SIZE;
+            framebuf.depth.stride = SDL_BYTESPERPIXEL(SDL_PIXELFORMAT_RGBA8888);
 
             framebuf.state.enable_depth  = true;
             framebuf.state.current_depth = 0.0f;
-            framebuf.state.transform     = Fang_Mat3x3Identity();
+            framebuf.state.transform     = Fang_IdentityMatrix();
 
             int error = SDL_LockTexture(
                 texture,


### PR DESCRIPTION
## Description

Cleaning up various structures and functions so that naming is more concise.

## Changes
- Simplify various structure names such as `Fang_Mat3x3` to `Fang_Matrix`
- Simplify various function names such as `Fang_FramebufferGetViewport()` to `Fang_GetViewport()`
- Use "fragment" in place of "pixel" for framebuffer functions
- Update `Fang_<type>Set` structures to pluralization of `<type>`s' names
- Update functions to generally follow <verb><base-type>, e.g. `Fang_GetEntity()`
- Ensure simple state-retrieval/validation functions follow <base-type><conjugate-verb>, e.g. `Fang_InputPressed()`

