### PR TITLE
Add 'Optimized' Build Configuration

### DIFF
--- a/Fang.sublime-project
+++ b/Fang.sublime-project
@@ -44,39 +44,13 @@
             },
             "variants": [
                 {
-                    "name": "Debug",
+                    "name": "Optimized",
                     "osx": {
                         "cmd": [
                             "sh",
                             "Scripts/macOS/Compile.sh",
                             "run",
-                            "debug",
-                            "-DFANG_UNBUFFERED_STDOUT",
-                        ]
-                    },
-                },
-                {
-                    "name": "ASAN",
-                    "osx": {
-                        "cmd": [
-                            "sh",
-                            "Scripts/macOS/Compile.sh",
-                            "run",
-                            "debug",
-                            "asan",
-                            "-DFANG_UNBUFFERED_STDOUT",
-                        ]
-                    },
-                },
-                {
-                    "name": "UBSAN",
-                    "osx": {
-                        "cmd": [
-                            "sh",
-                            "Scripts/macOS/Compile.sh",
-                            "run",
-                            "debug",
-                            "ubsan",
+                            "optimized",
                             "-DFANG_UNBUFFERED_STDOUT",
                         ]
                     },

--- a/Scripts/macOS/Compile.sh
+++ b/Scripts/macOS/Compile.sh
@@ -22,14 +22,17 @@ VERSION="0.0.0"
 
 RUN=0
 DEBUG=0
+OPTIMIZED=0
 RELEASE=0
 
 COMPILE_FLAGS=" "
 
+HELP_TEXT="\$Compile.sh [optimized|release] [asan|ubsan] [debug|run]"
+
 while [ "$1" != "" ]; do
     case $1 in
         "help" )
-            echo "\$./Scripts/macOS/Compile.sh [debug|release] [asan|ubsan] [run]"
+            echo HELP_TEXT
             exit 0
             ;;
 
@@ -41,6 +44,10 @@ while [ "$1" != "" ]; do
         "asan" )
             echo "Compiling with address sanitizer..."
             COMPILE_FLAGS+="-fsanitize=address "
+            ;;
+
+        "optimized" )
+            OPTIMIZED=1
             ;;
 
         "release" )
@@ -80,12 +87,21 @@ DIR_BUILD="Build"
 
 if test $RELEASE -eq 1; then
     COMPILE_FLAGS+="-O3 "
+    COMPILE_FLAGS+="-DNDEBUG "
     COMPILE_FLAGS+="-Wframe-larger-than=4096 "
     DIR_BUILD+="/Release"
+elif test $OPTIMIZED -eq 1; then
+    COMPILE_FLAGS+="-O3 "
+    COMPILE_FLAGS+="-Wno-unused-function "
+    COMPILE_FLAGS+="-Wno-unused-label "
+    COMPILE_FLAGS+="-Wno-unused-variable "
+    COMPILE_FLAGS+="-Wframe-larger-than=4096 "
+    DIR_BUILD+="/Optimized"
 else
     COMPILE_FLAGS+="-g "
     COMPILE_FLAGS+="-Wno-unused-function "
     COMPILE_FLAGS+="-Wno-unused-label "
+    COMPILE_FLAGS+="-Wno-unused-variable "
     COMPILE_FLAGS+="-Wframe-larger-than=8192 "
     DIR_BUILD+="/Debug"
 fi


### PR DESCRIPTION
Resolves #83 

## Description

Adds an optimized configuration that allows for testing optimized builds
without certain compiler warnings.

## Changes
- Adds optimized build configuration:
  - Disables warnings about unused functions, variables, and labels
  - Compiles with optimization level `O3`
  - Decreases stack frame size warning threshold from 8kB to 4kB
- Disables assertions in the Release configuration
- Removes unused asan/ubsan Sublime build configurations
- Changes the meaning of the `debug` parameter (now mutually exclusive with `run`) so that passing it runs the debugger. Running the compile script without `optimized` or `release` will build the game in debug mode, but not run it or the debugger by default