### PR TITLE
Move Framebuffer Allocation Into The Game Layer

### DIFF
--- a/Source/Fang/Fang_Constants.c
+++ b/Source/Fang/Fang_Constants.c
@@ -13,6 +13,10 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+enum {
+  FANG_WINDOW_SIZE = 256,
+};
+
 static const float FANG_PROJECTION_RATIO = 1.0f / (1.0f / 2.0f);
 
 enum {

--- a/Source/Fang/Fang_State.c
+++ b/Source/Fang/Fang_State.c
@@ -30,14 +30,15 @@ typedef struct Fang_Clock {
  * not indicative of the game's "save state".
 **/
 typedef struct Fang_State {
-    Fang_Map       map;
-    Fang_Textures  textures;
-    Fang_Ray       raycast[FANG_WINDOW_SIZE];
-    Fang_Clock     clock;
-    Fang_Camera    camera;
-    Fang_EntityId  player;
-    Fang_Interface interface;
-    Fang_Entities  entities;
-    Fang_LerpVec2  sway;
-    float          bob;
+    Fang_Framebuffer framebuffer;
+    Fang_Map         map;
+    Fang_Textures    textures;
+    Fang_Ray         raycast[FANG_WINDOW_SIZE];
+    Fang_Clock       clock;
+    Fang_Camera      camera;
+    Fang_EntityId    player;
+    Fang_Interface   interface;
+    Fang_Entities    entities;
+    Fang_LerpVec2    sway;
+    float            bob;
 } Fang_State;

--- a/Source/Main.c
+++ b/Source/Main.c
@@ -13,10 +13,6 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-enum {
-  FANG_WINDOW_SIZE = 256,
-};
-
 #include "Platform/FangSDL.c"
 
 int main(int argc, char **argv)


### PR DESCRIPTION
## Description

The game layer is the one that should be responsible for the management of this

## Changes
- Moves framebuffer storage to `Fang_State` and its allocation into `Fang_Init()` 
- Modifies `Fang_Update()` to return a pointer to the frame image that the platform layer should render
- Moves `FANG_WINDOW_SIZE` over to `Fang_Constants.c`

