### PR TITLE
Correct atan2f() Argument Order In Angle Calculation

### DIFF
--- a/Source/Fang/Fang_Render.c
+++ b/Source/Fang/Fang_Render.c
@@ -367,7 +367,7 @@ Fang_DrawMapSkybox(
         (Fang_Vec2){.x = 0.0f, .y = -1.0f}
     );
 
-    const float ratio = -(angle / ((float)M_PI / 2.0f)) * 2.0f;
+    const float ratio = (angle / ((float)M_PI / 2.0f)) * 2.0f;
 
     const Fang_Rect dest = {
         .x = (int)(viewport.w * ratio),

--- a/Source/Fang/Fang_Vector.c
+++ b/Source/Fang/Fang_Vector.c
@@ -92,19 +92,11 @@ Fang_Vec2Dot(
 }
 
 static inline float
-Fang_Vec2Determ(
+Fang_Vec2Cross(
     const Fang_Vec2 a,
     const Fang_Vec2 b)
 {
     return (a.x * b.y) - (a.y * b.x);
-}
-
-static inline float
-Fang_Vec2Angle(
-    const Fang_Vec2 a,
-    const Fang_Vec2 b)
-{
-    return atan2f(Fang_Vec2Dot(a, b), Fang_Vec2Determ(a, b));
 }
 
 static inline float
@@ -133,4 +125,12 @@ Fang_Vec3Normalize(
     const Fang_Vec3 a)
 {
     return Fang_Vec3Divf(a, Fang_Vec3Norm(a));
+}
+
+static inline float
+Fang_Vec2Angle(
+    const Fang_Vec2 a,
+    const Fang_Vec2 b)
+{
+    return atan2f(Fang_Vec2Cross(a, b), Fang_Vec2Dot(a, b));
 }


### PR DESCRIPTION
## Description

Corrects the argument order when calculating vector angles, it seems flipping them
only caused a flipped sign but still had the right value.

Also somewhere along the line the function for a cross product of 2D vectors was
named with "determ(inant)", which is now updated to the correct name.

## Changes
- Correct bad function name
- Flip arguments in `atan2f()` call inside `Fang_Vec2Angle()`
- Moves `Fang_Vec2Angle()` to the end of `Fang_Vector.c` 

