### PR TITLE
Update Max Allowed Entities Per Chunk

### DIFF
--- a/Source/Fang/Fang.c
+++ b/Source/Fang/Fang.c
@@ -405,13 +405,6 @@ Fang_Update(
                     &gamestate.map.chunks, &entity->body.pos
                 );
 
-                if (i == 0)
-                {
-                    assert(entity->type == FANG_ENTITYTYPE_PLAYER);
-
-                    printf("Other entities in your chunk:\n");
-                }
-
                 for (size_t j = 0; j < chunk->entities.count; ++j)
                 {
                     if (chunk->entities.entities[j] == entity->id)
@@ -423,20 +416,6 @@ Fang_Update(
 
                     if (!other)
                         continue;
-
-                    if (i == 0)
-                    {
-                        const char * name;
-                        switch (other->type)
-                        {
-                            case FANG_ENTITYTYPE_PLAYER:     name = "Player"; break;
-                            case FANG_ENTITYTYPE_PROJECTILE: name = "Projectile"; break;
-                            case FANG_ENTITYTYPE_AMMO:       name = "Ammo"; break;
-                            case FANG_ENTITYTYPE_HEALTH:     name = "Health"; break;
-                        }
-
-                        printf("\t%zu - %s\n", other->id, name);
-                    }
 
                     if (Fang_BodiesIntersect(&entity->body, &other->body))
                     {

--- a/Source/Fang/Fang_Constants.c
+++ b/Source/Fang/Fang_Constants.c
@@ -22,7 +22,7 @@ static const float FANG_PROJECTION_RATIO = 1.0f / (1.0f / 2.0f);
 enum {
     FANG_CHUNK_SIZE  = 16,
     FANG_CHUNK_COUNT = 1 << 12,
-    FANG_CHUNK_ENTITY_CAPACITY = 16,
+    FANG_CHUNK_ENTITY_CAPACITY = 128,
     FANG_CHUNK_MAX =  (1 << 6) - 1,
     FANG_CHUNK_MIN = -(1 << 6),
 };


### PR DESCRIPTION
Resolves #79 

## Description

Based from https://github.com/lassandroan/Fang/issues/79#issuecomment-1092981480

In this situation we'll allocate a static ~2MB (`(1 << 12) chunks * (4 bytes per ID * 128 chunk-entities)`) rather than trying to handle buckets of entities per chunk

## Changes
- Updates `FANG_CHUNK_ENTITY_CAPACITY` to 128
- Removes leftover entity-chunk debug logging
